### PR TITLE
fix: make subscriber payload ranges required

### DIFF
--- a/aether/orchestrator/docker_manager.py
+++ b/aether/orchestrator/docker_manager.py
@@ -189,15 +189,7 @@ class DockerManager:
         host_port = 9100 + subscriber_id * 10
         host_status_port = 19100 + subscriber_id * 10
 
-        range_args = (
-            f"--range-low {req.range_low} --range-high {req.range_high}"
-            if req.range_low is not None and req.range_high is not None
-            else ""
-        )
-
-        print("req.broker_id", req.broker_id)
-        print("req.broker's range_low", req.range_low)
-        print("req.broker's range_high", req.range_high)
+        range_args = f"--range-low {req.range_low} --range-high {req.range_high}"
 
         container = self.client.containers.run(
             settings.aether_image,

--- a/aether/orchestrator/main.py
+++ b/aether/orchestrator/main.py
@@ -8,6 +8,9 @@ import docker.errors
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 
+from aether.core.payload_range import partition_payload_space
+from aether.core.uint8 import UInt8
+
 from .docker_manager import DockerManager
 from .events import EventBroadcaster
 from .models import (
@@ -205,22 +208,33 @@ async def seed_demo() -> dict:
             info = docker_mgr.create_publisher(
                 CreatePublisherRequest(broker_ids=broker_ids)
             )
-            await broadcaster.emit(EventType.PUBLISHER_ADDED, info.model_dump(mode="json"))
+            await broadcaster.emit(
+                EventType.PUBLISHER_ADDED, info.model_dump(mode="json")
+            )
             created.append(info)
 
         # Subscribers: one per broker, bring total up to 3
         subscribers_needed = 3 - len(state.subscribers)
-        for broker_id in broker_ids[: max(0, subscribers_needed)]:
+        seed_ranges = partition_payload_space(UInt8(3))
+        for i, broker_id in enumerate(broker_ids[: max(0, subscribers_needed)]):
+            r = seed_ranges[i]
             info = docker_mgr.create_subscriber(
-                CreateSubscriberRequest(broker_id=broker_id)
+                CreateSubscriberRequest(
+                    broker_id=broker_id, range_low=int(r.low), range_high=int(r.high)
+                )
             )
-            await broadcaster.emit(EventType.SUBSCRIBER_ADDED, info.model_dump(mode="json"))
+            await broadcaster.emit(
+                EventType.SUBSCRIBER_ADDED, info.model_dump(mode="json")
+            )
             created.append(info)
 
     except docker.errors.APIError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    return {"seeded": len(created), "components": [c.model_dump(mode="json") for c in created]}
+    return {
+        "seeded": len(created),
+        "components": [c.model_dump(mode="json") for c in created],
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/aether/orchestrator/models.py
+++ b/aether/orchestrator/models.py
@@ -88,8 +88,8 @@ class CreatePublisherRequest(BaseModel):
 class CreateSubscriberRequest(BaseModel):
     subscriber_id: int | None = None
     broker_id: int  # required — subscriber needs exactly one broker
-    range_low: int | None = Field(default=None, ge=0, le=255)
-    range_high: int | None = Field(default=None, ge=0, le=255)
+    range_low: int = Field(ge=0, le=255)
+    range_high: int = Field(ge=0, le=255)
 
 
 class TriggerSnapshotRequest(BaseModel):

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1,0 +1,105 @@
+# Orchestrator Issues
+
+Discovered during audit of the orchestrator's state management, API endpoints, and container lifecycle. Ordered by severity.
+
+---
+
+## Issue #1: ComponentStatus never transitions from STARTING to RUNNING
+
+**Severity:** Critical
+**File:** `aether/orchestrator/docker_manager.py`
+
+**Description:**
+`ComponentInfo.status` defaults to `ComponentStatus.STARTING` but is never updated to `RUNNING` anywhere in the codebase. The only place `RUNNING` is checked is `_running_broker_ids()`, which filters brokers by `status == ComponentStatus.RUNNING`. Since no broker ever reaches that state, the method always returns an empty list.
+
+**Impact:**
+Any publisher created via `POST /api/publishers` without explicit `broker_ids` calls `_running_broker_ids()`, gets `[]`, and launches with zero broker connections — completely non-functional.
+
+**Reproduction:**
+1. `POST /api/brokers` (create a broker)
+2. `POST /api/publishers` (no body — relies on auto-detection)
+3. Observe the publisher's `broker_ids` is `[]` in `GET /api/state`
+
+**Fix:**
+Set `info.status = ComponentStatus.RUNNING` after each successful `self.client.containers.run()` call in `create_broker()`, `create_publisher()`, and `create_subscriber()`. Set `ComponentStatus.STOPPED` in the corresponding remove methods before deleting from `_components`.
+
+---
+
+## Issue #2: No reconciliation between _components and Docker container state
+
+**Severity:** Critical
+**File:** `aether/orchestrator/docker_manager.py`
+
+**Description:**
+`_components` is a pure in-memory dict that is only updated on explicit create/remove API calls. If a container crashes, is killed externally (`docker kill`), or exits on its own, `_components` still shows it with its last known status. There is no health check, no polling, and no sync mechanism.
+
+**Impact:**
+- `GET /api/state` returns stale data — crashed containers appear healthy
+- `GET /api/state/topology` draws edges to dead components
+- `GET /api/metrics` tries to poll dead containers (silently returns `{}` but still counts them)
+- No way for the frontend dashboard to know a component has failed
+
+**Reproduction:**
+1. `make demo` (seed the topology)
+2. `docker kill aether-broker-1`
+3. `GET /api/state` — broker-1 still shows `status: "starting"`
+
+**Fix:**
+Add a `_sync_component_status()` helper that iterates `_components`, calls `self.client.containers.get(info.container_id)`, and maps Docker's container status (`"running"`, `"exited"`, `"dead"`, `"created"`) to `ComponentStatus` values. Call it at the top of `get_system_state()`, `get_metrics()`, and `get_topology()`.
+
+---
+
+## Issue #3: Port collisions across component types at high IDs
+
+**Severity:** High
+**File:** `aether/orchestrator/docker_manager.py`
+
+**Description:**
+Host port formulas for different component types occupy overlapping ranges:
+
+| Component | Formula | Range |
+|-----------|---------|-------|
+| Broker | `8000 + id * 10` | 8000+ |
+| Publisher | `9000 + id * 10` | 9000+ |
+| Subscriber | `9100 + id * 10` | 9100+ |
+
+Collisions occur at:
+- Broker ID 100 → port 9000 = Publisher ID 0
+- Broker ID 110 → port 9100 = Subscriber ID 0
+- Publisher ID 10 → port 9100 = Subscriber ID 0
+
+**Impact:**
+Docker fails with `"Address already in use"` when the second container tries to bind the same host port. The API returns a generic 500 error with no clear explanation.
+
+**Reproduction:**
+1. `POST /api/publishers` (gets ID 1, port 9010)
+2. `POST /api/brokers` with `{"broker_id": 101}` → port `8000 + 101*10 = 9010` — collision
+
+**Fix:**
+Add a `_check_port_available(port)` helper that scans `_components` for existing `host_port`/`host_status_port` allocations. Call it before `containers.run()` in all three create methods. Raise `ValueError` on conflict so the API returns a clear 400-level error instead of a Docker 500.
+
+---
+
+## Issue #4: WebSocket broadcaster catches bare Exception
+
+**Severity:** Medium
+**File:** `aether/orchestrator/events.py`
+
+**Description:**
+The `emit()` method catches `Exception` broadly when sending to WebSocket clients:
+
+```python
+for ws in self._connections:
+    try:
+        await ws.send_text(message)
+    except Exception:
+        dead.add(ws)
+```
+
+**Impact:**
+- Any non-connection error (e.g., unexpected `TypeError`, `AttributeError`) is silently swallowed
+- No logging — impossible to diagnose failures
+- A healthy WebSocket client could be incorrectly marked as dead and removed if a non-connection exception occurs
+
+**Fix:**
+Narrow the catch to connection-related exceptions (`WebSocketDisconnect`, `RuntimeError`, `ConnectionError`) and add `logger.debug()` for visibility.

--- a/docs/plan-required-payload-ranges.md
+++ b/docs/plan-required-payload-ranges.md
@@ -1,0 +1,116 @@
+# Plan: Make Subscriber Payload Ranges Required
+
+## Context
+
+`CreateSubscriberRequest` has optional `range_low`/`range_high` fields. When omitted:
+1. The orchestrator stores `null` in `ComponentInfo` → `GET /api/state` shows `range_low: null, range_high: null`
+2. The subscriber container silently auto-computes its range via `partition_payload_space(total_subscribers)` in `run_subscribers.py`
+3. The orchestrator has no visibility into what range was actually assigned
+
+Beyond the visibility gap, `partition_payload_space(total_subscribers)` is broken in a dynamic system — `total_subscribers` is a moving target, so adding subscribers one at a time produces overlapping or gapped payload coverage.
+
+**Decision:** Make `range_low` and `range_high` required. The orchestrator always passes them explicitly. Range assignment is the API consumer's responsibility. The auto-partition fallback stays in `run_subscribers.py` for standalone CLI use only.
+
+---
+
+## Step 1: `aether/orchestrator/models.py` — Make ranges required
+
+**Lines 88–92** — Remove `Optional` and `None` defaults:
+
+```python
+# Before
+class CreateSubscriberRequest(BaseModel):
+    subscriber_id: int | None = None
+    broker_id: int  # required — subscriber needs exactly one broker
+    range_low: int | None = Field(default=None, ge=0, le=255)
+    range_high: int | None = Field(default=None, ge=0, le=255)
+
+# After
+class CreateSubscriberRequest(BaseModel):
+    subscriber_id: int | None = None
+    broker_id: int  # required — subscriber needs exactly one broker
+    range_low: int = Field(ge=0, le=255)   # required — caller owns range assignment
+    range_high: int = Field(ge=0, le=255)  # required — caller owns range assignment
+```
+
+`ComponentInfo.range_low`/`range_high` (lines 71–72) stay as `int | None = None` since they're shared across all component types and only apply to subscribers.
+
+---
+
+## Step 2: `aether/orchestrator/docker_manager.py` — Always pass ranges, remove debug prints
+
+**Lines 192–200** — Remove conditional `range_args` and the 3 debug `print()` statements:
+
+```python
+# Before (lines 192-200)
+range_args = (
+    f"--range-low {req.range_low} --range-high {req.range_high}"
+    if req.range_low is not None and req.range_high is not None
+    else ""
+)
+
+print("req.broker_id", req.broker_id)
+print("req.broker's range_low", req.range_low)
+print("req.broker's range_high", req.range_high)
+
+# After
+range_args = f"--range-low {req.range_low} --range-high {req.range_high}"
+```
+
+No other changes needed in this file — `ComponentInfo` construction (lines 232–234) already assigns `req.range_low` and `req.range_high` directly.
+
+---
+
+## Step 3: `aether/orchestrator/main.py` — Fix `/api/seed` to pass explicit ranges
+
+**Lines 211–218** — The seed creates 3 subscribers without ranges. Import `partition_payload_space` and compute ranges for the 3 demo subscribers:
+
+Add import at top of file:
+```python
+from aether.core.payload_range import partition_payload_space
+from aether.core.uint8 import UInt8
+```
+
+Update seed subscriber creation (lines 211–218):
+```python
+# Before
+subscribers_needed = 3 - len(state.subscribers)
+for broker_id in broker_ids[: max(0, subscribers_needed)]:
+    info = docker_mgr.create_subscriber(
+        CreateSubscriberRequest(broker_id=broker_id)
+    )
+
+# After
+subscribers_needed = 3 - len(state.subscribers)
+seed_ranges = partition_payload_space(UInt8(3))
+for i, broker_id in enumerate(broker_ids[: max(0, subscribers_needed)]):
+    r = seed_ranges[i]
+    info = docker_mgr.create_subscriber(
+        CreateSubscriberRequest(
+            broker_id=broker_id,
+            range_low=int(r.low),
+            range_high=int(r.high),
+        )
+    )
+```
+
+This gives the demo subscribers `[0-84]`, `[85-169]`, `[170-255]`.
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `aether/orchestrator/models.py:88-92` | `range_low`/`range_high` → required fields |
+| `aether/orchestrator/docker_manager.py:192-200` | Remove conditional range_args + remove 3 print statements |
+| `aether/orchestrator/main.py:1-24,211-218` | Add imports, pass explicit ranges in seed |
+
+---
+
+## Verification
+
+1. **API validation:** `POST /api/subscribers` with body `{"broker_id": 1}` (no ranges) → should return **422 Validation Error**
+2. **API happy path:** `POST /api/subscribers` with `{"broker_id": 1, "range_low": 0, "range_high": 127}` → should succeed, `ComponentInfo` has non-null ranges
+3. **Demo seed:** `make demo` → `GET /api/state` → all 3 subscribers show `range_low`/`range_high` values (0-84, 85-169, 170-255)
+4. **Standalone CLI:** `aether-subscriber --subscriber-id 0 --host localhost --port 9100 --broker-host localhost --broker-port 8000` (no range args) → still works via auto-partition fallback in `run_subscribers.py` (untouched)


### PR DESCRIPTION
## Summary

- **Make `range_low` and `range_high` required** in `CreateSubscriberRequest` — the orchestrator always passes them explicitly to subscriber containers
- **Update `/api/seed`** to compute explicit ranges for the 3 demo subscribers using `partition_payload_space(3)` → `[0-84]`, `[85-169]`, `[170-255]`
- **Remove conditional `range_args`** logic in `docker_manager.py` — always pass `--range-low`/`--range-high` CLI args
- **Remove debug `print()` statements** left in `create_subscriber()`

## Context

`range_low`/`range_high` were optional fields. When omitted, the orchestrator stored `null` in `ComponentInfo` while the subscriber container silently auto-computed its own range via `partition_payload_space(total_subscribers)`. This caused `GET /api/state` to show `range_low: null, range_high: null` for all subscribers.

Beyond the visibility gap, `partition_payload_space(total_subscribers)` is fundamentally broken in a dynamic system — `total_subscribers` is a moving target, so adding subscribers one at a time produces overlapping or gapped coverage. Range assignment is a cluster-level concern that belongs to the API consumer, not inside the container.

The auto-partition fallback remains in `run_subscribers.py` for standalone CLI use (running without the orchestrator).

## Test plan

- [ ] `POST /api/subscribers` with `{"broker_id": 1}` (no ranges) → 422 Validation Error
- [ ] `POST /api/subscribers` with `{"broker_id": 1, "range_low": 0, "range_high": 127}` → succeeds with non-null ranges in response
- [ ] `make demo` → `GET /api/state` → all 3 subscribers show `range_low`/`range_high` values
- [ ] Standalone CLI `aether-subscriber --subscriber-id 0 ...` without range args → still works via auto-partition fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)