### PR TITLE
fix(events): narrow WebSocket exception catch and add debug logging

### DIFF
--- a/aether/orchestrator/events.py
+++ b/aether/orchestrator/events.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 
 from fastapi import WebSocket
+from starlette.websockets import WebSocketDisconnect
+
+logger = logging.getLogger(__name__)
 
 
 class EventBroadcaster:
@@ -37,6 +41,7 @@ class EventBroadcaster:
         for ws in self._connections:
             try:
                 await ws.send_text(message)
-            except Exception:
+            except (WebSocketDisconnect, RuntimeError, ConnectionError) as e:
+                logger.debug("WebSocket client disconnected during emit: %s", e)
                 dead.add(ws)
         self._connections -= dead


### PR DESCRIPTION
## Summary
- Replaces bare `Exception` catch in `EventBroadcaster.emit()` with specific connection-related exceptions (`WebSocketDisconnect`, `RuntimeError`, `ConnectionError`)
- Adds `logger.debug()` so disconnection events are visible in logs
- Prevents healthy WebSocket clients from being incorrectly marked dead due to unrelated exceptions (e.g. `TypeError`, `AttributeError`)

## Test plan
- [ ] Start the orchestrator and connect a WebSocket client
- [ ] Kill the client abruptly — verify it is removed from `_connections` and a debug log line appears
- [ ] Trigger a non-connection exception (e.g. mock `send_text` to raise `TypeError`) — verify it propagates rather than being swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)