### PR TITLE
feat(dashboard): dockerize React frontend with nginx reverse proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for aether distributed messaging system
 # Targets documented in docs/instructions.md and docs/roadmap.md
 
-.PHONY: demo status logs clean build test lint up down restart ps check-ports
+.PHONY: demo status logs clean build build-dashboard test lint up down restart ps check-ports
 
 # Colors for better output
 GREEN = \033[0;32m
@@ -15,7 +15,8 @@ NC = \033[0m # No Color
 # dynamically by the orchestrator via the Docker SDK.
 BOOTSTRAP_STATUS_PORT = 17100
 ORCHESTRATOR_PORT     = 9000
-ALL_PORTS = $(BOOTSTRAP_STATUS_PORT) $(ORCHESTRATOR_PORT)
+DASHBOARD_PORT        = 3000
+ALL_PORTS = $(BOOTSTRAP_STATUS_PORT) $(ORCHESTRATOR_PORT) $(DASHBOARD_PORT)
 
 # Default target
 all: help
@@ -54,6 +55,7 @@ demo: build check-ports
 	@echo "  $(BLUE)API docs:$(NC)      http://localhost:$(ORCHESTRATOR_PORT)/docs"
 	@echo "  $(BLUE)System state:$(NC)  http://localhost:$(ORCHESTRATOR_PORT)/api/state"
 	@echo "  $(BLUE)Live events:$(NC)   ws://localhost:$(ORCHESTRATOR_PORT)/ws/events"
+	@echo "  $(BLUE)Dashboard:$(NC)     http://localhost:$(DASHBOARD_PORT)"
 
 status:
 	@echo "$(YELLOW)System state (via orchestrator):$(NC)"
@@ -73,6 +75,10 @@ clean:
 build:
 	@echo "$(YELLOW)Building Docker images...$(NC)"
 	@docker-compose build
+
+build-dashboard:
+	@echo "$(YELLOW)Building dashboard image...$(NC)"
+	@docker-compose build dashboard
 
 test:
 	@echo "$(YELLOW)Running unit tests...$(NC)"

--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.vite
+*.local
+.env
+.env.*
+README.md

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,28 @@
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copy dependency manifests first for layer caching
+COPY package.json package-lock.json ./
+
+RUN npm ci --frozen-lockfile
+
+# Copy source
+COPY . .
+
+# TypeScript type-check + Vite bundle → /app/dist
+RUN npm run build
+
+# ── Stage 2: serve ────────────────────────────────────────────────────────────
+FROM nginx:1.27-alpine
+
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY nginx.conf /etc/nginx/conf.d/dashboard.conf
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -1,0 +1,46 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    # ── REST API proxy ─────────────────────────────────────────────────────────
+    location /api/ {
+        proxy_pass         http://orchestrator:9000/api/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
+    # ── WebSocket proxy ────────────────────────────────────────────────────────
+    location /ws/ {
+        proxy_pass         http://orchestrator:9000/ws/;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade           $http_upgrade;
+        proxy_set_header   Connection        "upgrade";
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    # ── SPA fallback ───────────────────────────────────────────────────────────
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache Vite fingerprinted assets (content-hashed filenames → immutable)
+    location ~* \.(js|css|woff2?|svg|png|ico)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+}

--- a/dashboard/src/components/TopologyGraph.tsx
+++ b/dashboard/src/components/TopologyGraph.tsx
@@ -207,7 +207,7 @@ export default function TopologyGraph() {
 
   // Drag behavior
   const handleDragStart = useCallback(
-    (event: D3DragEvent<SVGGElement, PositionedNode, PositionedNode>, d: PositionedNode) => {
+    (_event: D3DragEvent<SVGGElement, PositionedNode, PositionedNode>, d: PositionedNode) => {
       const sim = simulation.current;
       if (sim) sim.alphaTarget(0.3).restart();
       d.fx = d.x;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,29 @@ services:
       - aether-net
     restart: "no"
 
+  # ── dashboard ──────────────────────────────────────────────────────────────
+  dashboard:
+    build:
+      context: ./dashboard
+      dockerfile: Dockerfile
+    image: aether-dashboard:latest
+    container_name: aether-dashboard
+    hostname: dashboard
+    ports:
+      - "3000:80"    # React dashboard (host 3000 → nginx 80)
+    depends_on:
+      orchestrator:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - aether-net
+    restart: "no"
+
 # ── network ───────────────────────────────────────────────────────────────
 networks:
   aether-net:


### PR DESCRIPTION
## Summary
- Adds a production Docker setup for the React dashboard (Phase 3 completion)
- Multi-stage `dashboard/Dockerfile`: node:22-alpine builds `dist/`, nginx:1.27-alpine serves it (~15 MB final image)
- `dashboard/nginx.conf` reverse-proxies `/api/*` and `/ws/*` to `orchestrator:9000` with correct WebSocket upgrade headers and 1h timeout; SPA fallback + immutable cache headers for Vite-fingerprinted assets
- Adds `dashboard` service to `docker-compose.yml` on port `3000:80`, depends on orchestrator healthy
- Makefile: `DASHBOARD_PORT=3000` added to port check, dashboard URL printed in `make demo` output, new `build-dashboard` target
- Fixes TS6133 strict TypeScript error (unused drag event param) in `TopologyGraph.tsx` uncovered by the container build

## Test plan
- [ ] `make build` — both `aether:latest` and `aether-dashboard:latest` build cleanly
- [ ] `make demo` — all 3 containers start healthy (bootstrap → orchestrator → dashboard)
- [ ] `curl http://localhost:3000/` returns React app HTML
- [ ] `curl http://localhost:3000/api/state` returns JSON via nginx → orchestrator proxy
- [ ] WebSocket at `ws://localhost:3000/ws/events` returns `101 Switching Protocols`
- [ ] `make check-ports` validates port 3000 alongside 9000 and 17100
- [ ] `make clean` tears everything down cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)