### PR TITLE
fix(benchmarks): harden sampled metrics contract

### DIFF
--- a/aether/orchestrator/docker_manager.py
+++ b/aether/orchestrator/docker_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import urllib.request
 from urllib.error import URLError
 
@@ -19,8 +20,10 @@ from .models import (
     CreateBrokerRequest,
     CreatePublisherRequest,
     CreateSubscriberRequest,
+    LatencyPercentiles,
     MetricsResponse,
     SnapshotStatusResponse,
+    SubscriberMetrics,
     SystemState,
     TopologyEdge,
     TopologyNode,
@@ -47,6 +50,10 @@ class DockerManager:
         self._components: dict[str, ComponentInfo] = (
             {}
         )  # container_name -> ComponentInfo
+        self._topology_generation: int = 0
+        self._last_total_messages: int = 0
+        self._last_metrics_time: float = 0.0
+        self._metrics_cache = MetricsResponse()
         self._ensure_network()
 
     def _ensure_network(self) -> None:
@@ -103,6 +110,7 @@ class DockerManager:
         )
         self._components[container_name] = info
         info.status = ComponentStatus.RUNNING
+        self._advance_topology_generation()
         logger.info("Started broker %d (container %s)", broker_id, container.id[:12])
         return info
 
@@ -114,6 +122,7 @@ class DockerManager:
         container.remove()
         remove_container_info.status = ComponentStatus.STOPPED
         del self._components[remove_container_info.container_name]
+        self._advance_topology_generation()
         logger.info(
             "Removed broker %d (container %s)",
             broker_id,
@@ -190,6 +199,7 @@ class DockerManager:
         )
         self._components[container_name] = info
         info.status = ComponentStatus.RUNNING
+        self._advance_topology_generation()
         logger.info(
             "Started publisher %d (container %s)", publisher_id, container.id[:12]
         )
@@ -203,6 +213,7 @@ class DockerManager:
         container.remove()
         info.status = ComponentStatus.STOPPED
         del self._components[info.container_name]
+        self._advance_topology_generation()
         logger.info(
             "Removed publisher %d (container %s)", publisher_id, info.container_id[:12]
         )
@@ -262,6 +273,7 @@ class DockerManager:
         )
         self._components[container_name] = info
         info.status = ComponentStatus.RUNNING
+        self._advance_topology_generation()
         logger.info(
             "Started subscriber %d (container %s)", subscriber_id, container.id[:12]
         )
@@ -275,6 +287,7 @@ class DockerManager:
         container.remove()
         info.status = ComponentStatus.STOPPED
         del self._components[info.container_name]
+        self._advance_topology_generation()
         logger.info(
             "Removed subscriber %d (container %s)",
             subscriber_id,
@@ -377,7 +390,20 @@ class DockerManager:
         return TopologyResponse(nodes=nodes, edges=edges)
 
     def get_metrics(self) -> MetricsResponse:
-        """Aggregate metrics by polling each broker's /status endpoint."""
+        """Return the latest cached metrics snapshot.
+
+        The authoritative sampler updates this cache on a fixed cadence via
+        ``refresh_metrics_cache()``. Reads must stay passive: no Docker sync,
+        no component fanout polling, and no mutation of throughput baselines.
+        """
+        return self._metrics_cache.model_copy(deep=True)
+
+    def refresh_metrics_cache(
+        self,
+        now: float | None = None,
+        fetched_at: float | None = None,
+    ) -> MetricsResponse:
+        """Aggregate metrics by polling broker and subscriber /status endpoints."""
         self._sync_component_status()
         brokers, publishers, subscribers = [], [], []
         for info in self._components.values():
@@ -407,13 +433,51 @@ class DockerManager:
                 )
             )
 
-        return MetricsResponse(
+        # Poll subscriber /status for latency percentiles.
+        subscriber_metrics = []
+        for info in subscribers:
+            raw = self._fetch_status(info.hostname, info.internal_status_port)
+            lat = raw.get("latency_us", {})
+            subscriber_metrics.append(
+                SubscriberMetrics(
+                    subscriber_id=info.component_id,
+                    broker_id=info.broker_id,
+                    total_received=raw.get("total_received", 0),
+                    latency_us=LatencyPercentiles(
+                        p50=lat.get("p50", 0),
+                        p95=lat.get("p95", 0),
+                        p99=lat.get("p99", 0),
+                        sample_count=lat.get("sample_count", 0),
+                    ),
+                )
+            )
+
+        # Compute throughput from the authoritative sampler delta only.
+        now = time.monotonic() if now is None else now
+        throughput = 0.0
+        sample_interval = 0.0
+        if self._last_metrics_time > 0:
+            sample_interval = now - self._last_metrics_time
+            if sample_interval > 0:
+                delta = total_messages - self._last_total_messages
+                throughput = max(0, delta / sample_interval)
+        self._last_total_messages = total_messages
+        self._last_metrics_time = now
+
+        sample = MetricsResponse(
             brokers=broker_metrics,
+            subscribers=subscriber_metrics,
             total_messages_processed=total_messages,
             total_brokers=len(brokers),
             total_publishers=len(publishers),
             total_subscribers=len(subscribers),
+            throughput_msgs_per_sec=round(throughput, 1),
+            topology_generation=self._topology_generation,
+            fetched_at=time.time() if fetched_at is None else fetched_at,
+            sample_interval_seconds=round(sample_interval, 3),
         )
+        self._metrics_cache = sample
+        return sample.model_copy(deep=True)
 
     def trigger_snapshot(
         self, initiator_broker_id: int | None
@@ -422,6 +486,15 @@ class DockerManager:
         raise NotImplementedError
 
     # --- Internal Helpers ---
+
+    def _advance_topology_generation(self) -> None:
+        """Invalidate cached metrics when component membership changes."""
+        self._topology_generation += 1
+        self._last_total_messages = 0
+        self._last_metrics_time = 0.0
+        self._metrics_cache = MetricsResponse(
+            topology_generation=self._topology_generation
+        )
 
     def _next_id(self, component_type: ComponentType, start: int = 1) -> int:
         """Return the lowest unused integer ID for the given component type."""

--- a/aether/orchestrator/main.py
+++ b/aether/orchestrator/main.py
@@ -365,20 +365,18 @@ async def _snapshot_monitor() -> None:
                             "broker_address": s.broker_address,
                             "snapshot_id": s.snapshot_id,
                             "subscriber_count": s.subscriber_count,
+                            "snapshot_timestamp": s.timestamp,
                         })
         except Exception:
             pass
 
 
 async def _metrics_updater() -> None:
-    """Background task that keeps Prometheus gauges and counters current.
+    """Background task that authoritatively samples live metrics.
 
-    Runs every 15 seconds. Piggybacks on docker_mgr.get_metrics(), which
-    already polls every running broker's /status endpoint for the /api/metrics
-    REST response — so this task adds no extra broker calls.
-
-    Why 5 seconds: matches Prometheus's scrape_interval so gauges are always
-    fresh by the time Prometheus pulls them.
+    This is the only path allowed to refresh orchestrator metrics from live
+    broker/subscriber status endpoints. ``GET /api/metrics`` serves the latest
+    cached snapshot produced here and must remain a passive read.
 
     Counter delta strategy for messages_published_total:
       Broker /status returns a cumulative count since that container started.
@@ -397,11 +395,12 @@ async def _metrics_updater() -> None:
     # of 1 indefinitely and the running-count panels never decrease.
     _seen_components: set[tuple[str, str]] = set()
 
-    _POLL_INTERVAL = 5.0
+    _POLL_INTERVAL = 1.0
 
     while True:
-        await asyncio.sleep(_POLL_INTERVAL)
         try:
+            broker_metrics = docker_mgr.refresh_metrics_cache()
+
             # --- Component up/down gauges -----------------------------------
             current_components: set[tuple[str, str]] = set()
             for info in docker_mgr._components.values():
@@ -422,8 +421,6 @@ async def _metrics_updater() -> None:
             _seen_components = current_components
 
             # --- Broker-level gauges + message counter ----------------------
-            broker_metrics = docker_mgr.get_metrics()
-
             for bm in broker_metrics.brokers:
                 bid = str(bm.broker_id)
                 metrics.broker_peer_count.labels(broker_id=bid).set(bm.peer_count)
@@ -446,6 +443,7 @@ async def _metrics_updater() -> None:
             # mid-restart shouldn't break the metrics loop. The next iteration
             # will pick up fresh values.
             logger.debug("metrics updater poll failed (non-critical)")
+        await asyncio.sleep(_POLL_INTERVAL)
 
 
 @app.get("/api/assignments")

--- a/aether/orchestrator/models.py
+++ b/aether/orchestrator/models.py
@@ -160,12 +160,31 @@ class BrokerMetrics(BaseModel):
     snapshot_state: str = "idle"  # "idle" | "recording"
 
 
+class LatencyPercentiles(BaseModel):
+    p50: float = 0
+    p95: float = 0
+    p99: float = 0
+    sample_count: int = 0
+
+
+class SubscriberMetrics(BaseModel):
+    subscriber_id: int
+    broker_id: int | None = None
+    total_received: int = 0
+    latency_us: LatencyPercentiles = Field(default_factory=LatencyPercentiles)
+
+
 class MetricsResponse(BaseModel):
     brokers: list[BrokerMetrics] = Field(default_factory=list)
+    subscribers: list[SubscriberMetrics] = Field(default_factory=list)
     total_messages_processed: int = 0
     total_brokers: int = 0
     total_publishers: int = 0
     total_subscribers: int = 0
+    throughput_msgs_per_sec: float = 0
+    topology_generation: int = 0
+    fetched_at: float = 0
+    sample_interval_seconds: float = 0
 
 
 class SnapshotStatusResponse(BaseModel):

--- a/benchmarks/client.py
+++ b/benchmarks/client.py
@@ -1,0 +1,580 @@
+"""Async client wrapper around the Aether orchestrator REST API + WebSocket."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+import httpx
+import websockets
+import websockets.asyncio.client
+
+from benchmarks.config import BenchmarkConfig
+
+logger = logging.getLogger(__name__)
+
+
+class AetherClient:
+    """Async HTTP client for the orchestrator API."""
+
+    def __init__(self, cfg: BenchmarkConfig) -> None:
+        self.cfg = cfg
+        self.base = cfg.orchestrator_url
+        self._http = httpx.AsyncClient(base_url=self.base, timeout=30.0)
+
+    async def close(self) -> None:
+        await self._http.aclose()
+
+    # ------------------------------------------------------------------
+    # Health / preflight
+    # ------------------------------------------------------------------
+
+    async def wait_ready(self, timeout: float = 60.0) -> None:
+        """Poll /api/state until orchestrator responds."""
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                resp = await self._http.get("/api/state")
+                if resp.status_code == 200:
+                    return
+            except httpx.ConnectError:
+                pass
+            await asyncio.sleep(1.0)
+        raise RuntimeError(
+            f"Orchestrator not reachable at {self.base} after {timeout}s. "
+            "Is the system running?  Run 'make demo' first."
+        )
+
+    # ------------------------------------------------------------------
+    # Topology management
+    # ------------------------------------------------------------------
+
+    async def seed_topology(
+        self,
+        brokers: int = 3,
+        publishers: int = 2,
+        subscribers: int = 3,
+        publish_interval: float | None = None,
+        publishers_last: bool = False,
+    ) -> dict[str, Any]:
+        """Seed a topology by building it piece by piece.
+
+        We never use /api/seed here — that endpoint hardcodes publish_interval=1.0
+        (intentional for the UI demo) which makes benchmark throughput numbers
+        useless. Always create publishers explicitly with cfg.publish_interval.
+
+        publish_interval overrides cfg.publish_interval when provided, allowing
+        latency benchmarks to use a slower rate that keeps the broker unsaturated.
+        """
+        interval = (
+            publish_interval
+            if publish_interval is not None
+            else self.cfg.publish_interval
+        )
+        created: list[dict] = []
+
+        state = await self.get_state()
+        existing_brokers = [b["component_id"] for b in state.get("brokers", [])]
+
+        # Create brokers up to target count.
+        while len(existing_brokers) < brokers:
+            info = await self._create_broker()
+            existing_brokers.append(info["component"]["component_id"])
+            created.append(info)
+
+        state = await self.get_state()
+        existing_brokers = [b["component_id"] for b in state.get("brokers", [])]
+
+        async def _create_publishers() -> None:
+            current_state = await self.get_state()
+            existing_pubs = len(current_state.get("publishers", []))
+            for _ in range(max(0, publishers - existing_pubs)):
+                info = await self._create_publisher(
+                    broker_ids=existing_brokers,
+                    interval=interval,
+                )
+                created.append(info)
+
+        # Create subscribers — one per broker, round-robin.
+        step = max(1, 256 // subscribers) if subscribers > 0 else 256
+        async def _create_subscribers() -> None:
+            current_state = await self.get_state()
+            existing_subs = len(current_state.get("subscribers", []))
+            subs_needed = max(0, subscribers - existing_subs)
+            for i in range(subs_needed):
+                broker_id = existing_brokers[i % len(existing_brokers)]
+                low = i * step
+                high = min((i + 1) * step - 1, 255)
+                info = await self._create_subscriber(broker_id, low, high)
+                created.append(info)
+
+        if publishers_last:
+            await _create_subscribers()
+            await _create_publishers()
+        else:
+            await _create_publishers()
+            await _create_subscribers()
+
+        return {"seeded": len(created), "components": created}
+
+    async def _create_broker(self) -> dict[str, Any]:
+        resp = await self._http.post("/api/brokers", json={})
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _create_publisher(
+        self, broker_ids: list[int] | None = None, interval: float = 1.0
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"interval": interval}
+        if broker_ids is not None:
+            body["broker_ids"] = broker_ids
+        resp = await self._http.post("/api/publishers", json=body)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _create_subscriber(
+        self, broker_id: int, range_low: int, range_high: int
+    ) -> dict[str, Any]:
+        resp = await self._http.post(
+            "/api/subscribers",
+            json={
+                "broker_id": broker_id,
+                "range_low": range_low,
+                "range_high": range_high,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def add_publisher(
+        self, broker_ids: list[int] | None = None, interval: float | None = None
+    ) -> dict[str, Any]:
+        if interval is None:
+            interval = self.cfg.publish_interval
+        return await self._create_publisher(broker_ids, interval)
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    async def get_state(self) -> dict[str, Any]:
+        resp = await self._http.get("/api/state")
+        resp.raise_for_status()
+        return resp.json()
+
+    async def get_metrics(self) -> dict[str, Any]:
+        resp = await self._http.get("/api/metrics")
+        resp.raise_for_status()
+        return resp.json()
+
+    def assert_valid_metrics_snapshot(
+        self,
+        metrics: dict[str, Any],
+        *,
+        stage: str,
+        expected_generation: int | None = None,
+    ) -> None:
+        """Validate cached metrics contract before a benchmark trusts a sample."""
+        actual_generation = metrics.get("topology_generation")
+        if actual_generation is None:
+            raise RuntimeError(f"missing metrics generation during {stage}")
+        if expected_generation is not None and actual_generation != expected_generation:
+            raise RuntimeError(
+                f"metrics generation changed during {stage}: "
+                f"expected={expected_generation}, actual={actual_generation}"
+            )
+
+        fetched_at = metrics.get("fetched_at", 0)
+        if fetched_at <= 0:
+            raise RuntimeError(f"missing metrics fetch timestamp during {stage}")
+
+        sample_interval = metrics.get("sample_interval_seconds", 0)
+        if sample_interval <= 0:
+            raise RuntimeError(f"invalid metrics sample interval during {stage}")
+
+        allowed_staleness = max(
+            self.cfg.metrics_max_staleness_seconds,
+            float(sample_interval) * 2,
+        )
+        age_seconds = time.time() - float(fetched_at)
+        if age_seconds > allowed_staleness:
+            raise RuntimeError(
+                f"stale metrics snapshot during {stage}: "
+                f"age={age_seconds:.3f}s, limit={allowed_staleness:.3f}s"
+            )
+
+    async def wait_for_metrics_generation(
+        self,
+        expected_generation: int,
+        *,
+        timeout: float = 10.0,
+        poll_interval: float = 0.2,
+    ) -> dict[str, Any]:
+        """Wait for the sampler to publish a fresh metrics snapshot for a generation."""
+        deadline = asyncio.get_event_loop().time() + timeout
+        last_metrics: dict[str, Any] | None = None
+
+        while asyncio.get_event_loop().time() < deadline:
+            metrics = await self.get_metrics()
+            last_metrics = metrics
+            if (
+                metrics.get("topology_generation") == expected_generation
+                and metrics.get("fetched_at", 0) > 0
+            ):
+                return metrics
+            await asyncio.sleep(poll_interval)
+
+        raise RuntimeError(
+            "timed out waiting for fresh metrics sample for topology generation "
+            f"{expected_generation}; last_sample={last_metrics}"
+        )
+
+    async def assert_metrics_generation(
+        self,
+        expected_generation: int,
+        *,
+        stage: str,
+    ) -> None:
+        """Fail fast if a measurement window crossed a topology boundary."""
+        metrics = await self.get_metrics()
+        actual_generation = metrics.get("topology_generation")
+        if actual_generation != expected_generation:
+            raise RuntimeError(
+                f"metrics generation changed during {stage}: "
+                f"expected={expected_generation}, actual={actual_generation}"
+            )
+
+    async def get_topology_fingerprint(self) -> dict[str, Any]:
+        """Capture the current dynamic topology in a comparison-friendly form."""
+        state = await self.get_state()
+        brokers = {
+            comp["component_id"]: comp.get("status")
+            for comp in state.get("brokers", [])
+        }
+        publishers = {
+            comp["component_id"]: {
+                "status": comp.get("status"),
+                "publish_interval": comp.get("publish_interval"),
+            }
+            for comp in state.get("publishers", [])
+        }
+        subscribers = {
+            comp["component_id"]: {
+                "status": comp.get("status"),
+                "broker_id": comp.get("broker_id"),
+                "range_low": comp.get("range_low"),
+                "range_high": comp.get("range_high"),
+            }
+            for comp in state.get("subscribers", [])
+        }
+        return {
+            "brokers": brokers,
+            "publishers": publishers,
+            "subscribers": subscribers,
+        }
+
+    async def assert_topology_matches(
+        self,
+        expected: dict[str, Any],
+        *,
+        stage: str,
+    ) -> None:
+        """Fail if the dynamic topology differs from the expected benchmark state."""
+        actual = await self.get_topology_fingerprint()
+        if actual != expected:
+            raise RuntimeError(
+                f"benchmark topology changed during {stage}: "
+                f"expected={expected}, actual={actual}"
+            )
+
+    async def get_subscriber_status(self, host: str, port: int) -> dict[str, Any]:
+        """Query a subscriber's /status endpoint directly (outside Docker network)."""
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(f"http://{host}:{port}/status")
+            resp.raise_for_status()
+            return resp.json()
+
+    async def reset_subscriber_latency(self, host: str, port: int) -> dict[str, Any]:
+        """Clear a subscriber's in-memory latency sample buffer."""
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(f"http://{host}:{port}/latency/reset")
+            resp.raise_for_status()
+            return resp.json()
+
+    # ------------------------------------------------------------------
+    # Chaos
+    # ------------------------------------------------------------------
+
+    async def trigger_chaos(self) -> dict[str, Any]:
+        resp = await self._http.post("/api/chaos")
+        resp.raise_for_status()
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    async def cleanup(self, timeout: float = 60.0) -> None:
+        """Remove all dynamic components and verify the system returns to empty."""
+        state = await self.get_state()
+        failures: list[str] = []
+
+        async def _delete(path: str, label: str) -> None:
+            try:
+                resp = await self._http.delete(path)
+                resp.raise_for_status()
+            except Exception as exc:
+                failures.append(f"{label}: {exc}")
+
+        for sub in state.get("subscribers", []):
+            await _delete(
+                f"/api/subscribers/{sub['component_id']}",
+                f"subscriber {sub['component_id']}",
+            )
+        for pub in state.get("publishers", []):
+            await _delete(
+                f"/api/publishers/{pub['component_id']}",
+                f"publisher {pub['component_id']}",
+            )
+        for broker in state.get("brokers", []):
+            await _delete(
+                f"/api/brokers/{broker['component_id']}",
+                f"broker {broker['component_id']}",
+            )
+
+        deadline = asyncio.get_event_loop().time() + timeout
+        final_state: dict[str, Any] | None = None
+        while asyncio.get_event_loop().time() < deadline:
+            final_state = await self.get_state()
+            if (
+                not final_state.get("brokers")
+                and not final_state.get("publishers")
+                and not final_state.get("subscribers")
+            ):
+                break
+            await asyncio.sleep(1.0)
+        else:
+            if final_state is None:
+                final_state = await self.get_state()
+            failures.append(
+                "cleanup did not converge to an empty topology within "
+                f"{timeout}s (remaining: "
+                f"brokers={len(final_state.get('brokers', []))}, "
+                f"publishers={len(final_state.get('publishers', []))}, "
+                f"subscribers={len(final_state.get('subscribers', []))})"
+            )
+
+        if failures:
+            raise RuntimeError("benchmark cleanup failed: " + "; ".join(failures))
+
+    # ------------------------------------------------------------------
+    # Wait for components to be running
+    # ------------------------------------------------------------------
+
+    async def wait_all_running(self, timeout: float = 60.0) -> None:
+        """Poll /api/state until every component has status RUNNING."""
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            state = await self.get_state()
+            all_components = (
+                state.get("brokers", [])
+                + state.get("publishers", [])
+                + state.get("subscribers", [])
+            )
+            if all_components and all(
+                c.get("status") == "running" for c in all_components
+            ):
+                return
+            await asyncio.sleep(1.0)
+        raise RuntimeError(f"Not all components reached RUNNING within {timeout}s")
+
+    async def wait_latency_ready(
+        self,
+        *,
+        expected_subscribers: int,
+        min_samples_per_subscriber: int,
+        stable_polls: int,
+        timeout: float,
+        poll_interval: float,
+    ) -> None:
+        """Wait until latency measurement prerequisites are stably true.
+
+        Readiness requires:
+          - the expected subscriber count exists
+          - total broker message count is still increasing
+          - every subscriber has received traffic
+          - every subscriber has accumulated enough latency samples
+          - these conditions hold for stable_polls consecutive polls
+        """
+        deadline = asyncio.get_event_loop().time() + timeout
+        prev_total_messages: int | None = None
+        expected_generation: int | None = None
+        ready_polls = 0
+        last_reason = "latency readiness has not started"
+
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                state = await self.get_state()
+                metrics = await self.get_metrics()
+            except Exception as exc:
+                ready_polls = 0
+                last_reason = f"failed to query readiness metrics: {exc}"
+                await asyncio.sleep(poll_interval)
+                continue
+
+            self.assert_valid_metrics_snapshot(
+                metrics,
+                stage="latency readiness",
+                expected_generation=expected_generation,
+            )
+            expected_generation = metrics["topology_generation"]
+
+            state_subscribers = state.get("subscribers", [])
+            if len(state_subscribers) != expected_subscribers:
+                ready_polls = 0
+                last_reason = (
+                    f"expected {expected_subscribers} subscribers, "
+                    f"found {len(state_subscribers)}"
+                )
+                prev_total_messages = metrics.get("total_messages_processed", 0)
+                await asyncio.sleep(poll_interval)
+                continue
+
+            subscriber_metrics = {
+                sub.get("subscriber_id"): sub for sub in metrics.get("subscribers", [])
+            }
+            missing_ids: list[int] = []
+            idle_ids: list[int] = []
+            undersampled: list[str] = []
+
+            for sub in state_subscribers:
+                subscriber_id = sub.get("component_id")
+                metric = subscriber_metrics.get(subscriber_id)
+                if metric is None:
+                    missing_ids.append(subscriber_id)
+                    continue
+
+                if metric.get("total_received", 0) <= 0:
+                    idle_ids.append(subscriber_id)
+
+                sample_count = metric.get("latency_us", {}).get("sample_count", 0)
+                if sample_count < min_samples_per_subscriber:
+                    undersampled.append(f"{subscriber_id}:{sample_count}")
+
+            total_messages = metrics.get("total_messages_processed", 0)
+            traffic_increasing = (
+                prev_total_messages is not None
+                and total_messages > prev_total_messages
+            )
+            prev_total_messages = total_messages
+
+            if missing_ids:
+                ready_polls = 0
+                last_reason = f"missing subscriber metrics for IDs {missing_ids}"
+            elif idle_ids:
+                ready_polls = 0
+                last_reason = f"subscribers with zero deliveries: {idle_ids}"
+            elif undersampled:
+                ready_polls = 0
+                last_reason = (
+                    "subscribers below minimum latency samples "
+                    f"({min_samples_per_subscriber}): {undersampled}"
+                )
+            elif not traffic_increasing:
+                ready_polls = 0
+                last_reason = "broker message count is not increasing between polls"
+            else:
+                ready_polls += 1
+                last_reason = (
+                    f"ready poll {ready_polls}/{stable_polls} "
+                    f"(messages_total={total_messages})"
+                )
+                if ready_polls >= stable_polls:
+                    return
+
+            await asyncio.sleep(poll_interval)
+
+        raise RuntimeError(
+            "Latency benchmark did not reach measurement readiness within "
+            f"{timeout}s: {last_reason}"
+        )
+
+    async def reset_all_subscriber_latency_samples(
+        self,
+        *,
+        expected_subscribers: int,
+    ) -> None:
+        """Reset latency sample buffers for all expected subscribers."""
+        state = await self.get_state()
+        subscribers = state.get("subscribers", [])
+        if len(subscribers) != expected_subscribers:
+            raise RuntimeError(
+                f"cannot reset latency samples: expected {expected_subscribers} "
+                f"subscribers, found {len(subscribers)}"
+            )
+
+        reset_calls = []
+        for sub in subscribers:
+            host_port = sub.get("host_status_port")
+            subscriber_id = sub.get("component_id")
+            if host_port is None:
+                raise RuntimeError(
+                    f"subscriber {subscriber_id} missing host_status_port"
+                )
+            reset_calls.append(self.reset_subscriber_latency("localhost", host_port))
+
+        results = await asyncio.gather(*reset_calls, return_exceptions=True)
+        failures = [
+            f"subscriber #{idx + 1}: {result}"
+            for idx, result in enumerate(results)
+            if isinstance(result, Exception)
+        ]
+        if failures:
+            raise RuntimeError(
+                "failed to reset subscriber latency samples: " + ", ".join(failures)
+            )
+
+
+# --------------------------------------------------------------------------
+# WebSocket event stream
+# --------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def event_stream(
+    cfg: BenchmarkConfig,
+) -> AsyncIterator[asyncio.Queue[dict[str, Any]]]:
+    """Connect to the orchestrator WebSocket and yield a queue of parsed events.
+
+    Usage::
+
+        async with event_stream(cfg) as events:
+            event = await asyncio.wait_for(events.get(), timeout=30)
+    """
+    ws_url = cfg.orchestrator_url.replace("http://", "ws://") + "/ws/events"
+    queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def _reader(ws: websockets.asyncio.client.ClientConnection) -> None:
+        try:
+            async for raw in ws:
+                try:
+                    queue.put_nowait(json.loads(raw))
+                except json.JSONDecodeError:
+                    pass
+        except websockets.exceptions.ConnectionClosed:
+            pass
+
+    async with websockets.asyncio.client.connect(ws_url) as ws:
+        task = asyncio.create_task(_reader(ws))
+        try:
+            yield queue
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass

--- a/benchmarks/collectors.py
+++ b/benchmarks/collectors.py
@@ -1,0 +1,271 @@
+"""Metric collection helpers for benchmarks."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from benchmarks.client import AetherClient
+
+
+async def collect_throughput(
+    client: AetherClient,
+    duration: float,
+    poll_interval: float = 1.0,
+) -> list[dict[str, Any]]:
+    """Poll /api/metrics for *duration* seconds and return per-interval samples.
+
+    Each sample: {"elapsed": float, "messages_total": int, "msgs_per_sec": float}
+    """
+    samples: list[dict[str, Any]] = []
+    start = time.monotonic()
+    prev_total: int | None = None
+    prev_time: float | None = None
+    consecutive_failures = 0
+
+    while time.monotonic() - start < duration:
+        try:
+            metrics = await client.get_metrics()
+            consecutive_failures = 0
+            now = time.monotonic()
+            if "total_messages_processed" not in metrics:
+                raise RuntimeError("metrics payload missing total_messages_processed")
+            total = metrics["total_messages_processed"]
+
+            if prev_total is not None and prev_time is not None:
+                dt = now - prev_time
+                if dt > 0:
+                    msgs_per_sec = (total - prev_total) / dt
+                    samples.append(
+                        {
+                            "elapsed": round(now - start, 2),
+                            "messages_total": total,
+                            "msgs_per_sec": round(msgs_per_sec, 1),
+                        }
+                    )
+
+            prev_total = total
+            prev_time = now
+        except Exception as exc:
+            consecutive_failures += 1
+            if consecutive_failures >= client.cfg.max_metrics_read_failures:
+                raise RuntimeError(
+                    "failed to collect throughput metrics after "
+                    f"{consecutive_failures} consecutive errors: {exc}"
+                ) from exc
+
+        await asyncio.sleep(poll_interval)
+
+    if len(samples) < client.cfg.min_throughput_samples:
+        raise RuntimeError(
+            "insufficient throughput samples: "
+            f"expected at least {client.cfg.min_throughput_samples}, got {len(samples)}"
+        )
+
+    return samples
+
+
+def compute_stats(values: list[float]) -> dict[str, float]:
+    """Compute summary statistics from a list of numeric values."""
+    if not values:
+        return {"mean": 0, "p50": 0, "p95": 0, "p99": 0, "max": 0, "min": 0, "count": 0}
+    s = sorted(values)
+    n = len(s)
+    return {
+        "mean": round(sum(s) / n, 2),
+        "p50": round(s[n // 2], 2),
+        "p95": round(s[int(n * 0.95)], 2),
+        "p99": round(s[int(n * 0.99)], 2),
+        "max": round(s[-1], 2),
+        "min": round(s[0], 2),
+        "count": n,
+    }
+
+
+async def collect_latency(
+    client: AetherClient,
+) -> dict[str, Any]:
+    """Harvest raw latency samples from subscriber /status endpoints.
+
+    Returns exact per-subscriber and cluster-wide percentiles computed from the
+    merged raw sample set rather than averaged per-subscriber percentiles.
+    """
+    state = await client.get_state()
+    subscriber_latencies: list[dict[str, Any]] = []
+    all_samples_us: list[float] = []
+
+    for sub in state.get("subscribers", []):
+        host_port = sub.get("host_status_port")
+        if host_port is None:
+            continue
+
+        status = await client.get_subscriber_status("localhost", host_port)
+        samples_us = status.get("latency_samples_us", [])
+        if not samples_us:
+            continue
+
+        sorted_samples_us = sorted(float(sample) for sample in samples_us)
+        all_samples_us.extend(sorted_samples_us)
+        subscriber_latencies.append(
+            {
+                "subscriber_id": sub.get("component_id"),
+                "broker_id": sub.get("broker_id"),
+                "sample_count": len(sorted_samples_us),
+                "latency_us": _compute_percentiles(sorted_samples_us),
+                "latency_samples_us": sorted_samples_us,
+            }
+        )
+
+    if not all_samples_us:
+        return {
+            "subscribers": [],
+            "aggregate": {"p50": 0, "p95": 0, "p99": 0, "sample_count": 0},
+        }
+
+    aggregate = _compute_percentiles(sorted(all_samples_us))
+    aggregate["sample_count"] = len(all_samples_us)
+
+    return {"subscribers": subscriber_latencies, "aggregate": aggregate}
+
+
+def _compute_percentiles(sorted_values: list[float]) -> dict[str, float]:
+    """Compute exact percentile picks from an already-sorted sample list."""
+    n = len(sorted_values)
+    if n == 0:
+        return {"p50": 0, "p95": 0, "p99": 0}
+    return {
+        "p50": round(sorted_values[n // 2], 1),
+        "p95": round(sorted_values[int(n * 0.95)], 1),
+        "p99": round(sorted_values[int(n * 0.99)], 1),
+    }
+
+
+async def collect_recovery_events(
+    events: asyncio.Queue[dict[str, Any]],
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    """Capture recovery event timestamps from the WebSocket event queue.
+
+    Waits for BROKER_DECLARED_DEAD -> BROKER_RECOVERED -> SUBSCRIBER_RECONNECTED.
+    Returns timing breakdown.
+    """
+    t_dead: float | None = None
+    t_recovery_started: float | None = None
+    t_recovered: float | None = None
+    recovery_path: str | None = None
+    reconnect_times: list[float] = []
+
+    deadline = asyncio.get_event_loop().time() + timeout
+
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            event = await asyncio.wait_for(events.get(), timeout=2.0)
+        except asyncio.TimeoutError:
+            if t_recovered is not None:
+                break
+            continue
+
+        etype = event.get("type", "")
+        ts = event.get("timestamp", 0)
+
+        if etype == "broker_declared_dead" and t_dead is None:
+            t_dead = ts
+        elif etype == "broker_recovery_started" and t_recovery_started is None:
+            t_recovery_started = ts
+            recovery_path = event.get("data", {}).get("recovery_path")
+        elif etype == "broker_recovered" and t_recovered is None:
+            t_recovered = ts
+            if recovery_path is None:
+                recovery_path = event.get("data", {}).get("recovery_path")
+        elif etype == "subscriber_reconnected":
+            reconnect_times.append(ts)
+
+    result: dict[str, Any] = {"recovery_path": recovery_path}
+
+    if t_dead is not None and t_recovered is not None:
+        result["detection_time_s"] = round(
+            (t_recovery_started or t_recovered) - t_dead, 3
+        )
+        result["recovery_time_s"] = round(t_recovered - t_dead, 3)
+    if t_dead is not None and reconnect_times:
+        result["subscriber_reconnect_time_s"] = round(max(reconnect_times) - t_dead, 3)
+
+    missing: list[str] = []
+    if t_dead is None:
+        missing.append("broker_declared_dead")
+    if t_recovery_started is None:
+        missing.append("broker_recovery_started")
+    if t_recovered is None:
+        missing.append("broker_recovered")
+    if not reconnect_times:
+        missing.append("subscriber_reconnected")
+    if missing:
+        raise RuntimeError(
+            "incomplete recovery event timeline: missing " + ", ".join(missing)
+        )
+
+    return result
+
+
+async def collect_snapshot_events(
+    events: asyncio.Queue[dict[str, Any]],
+    rounds: int = 3,
+    timeout_per_round: float = 30.0,
+) -> list[dict[str, Any]]:
+    """Capture SNAPSHOT_COMPLETE events and measure coordination overhead.
+
+    Returns per-round timing: time between first and last broker completing.
+    """
+    results: list[dict[str, Any]] = []
+    round_events: list[dict[str, Any]] = []
+    last_event_time: float = asyncio.get_event_loop().time()
+
+    while len(results) < rounds:
+        try:
+            event = await asyncio.wait_for(events.get(), timeout=timeout_per_round)
+        except asyncio.TimeoutError:
+            if round_events:
+                results.append(_summarize_snapshot_round(round_events))
+                round_events = []
+            break
+
+        if event.get("type") == "snapshot_complete":
+            now = asyncio.get_event_loop().time()
+            round_events.append(event)
+
+            # If >5s gap since last snapshot event, start a new round.
+            if now - last_event_time > 5.0 and len(round_events) > 1:
+                results.append(_summarize_snapshot_round(round_events[:-1]))
+                round_events = [round_events[-1]]
+
+            last_event_time = now
+
+    if round_events and len(results) < rounds:
+        results.append(_summarize_snapshot_round(round_events))
+
+    if len(results) < rounds:
+        raise RuntimeError(
+            "incomplete snapshot rounds: "
+            f"expected {rounds}, got {len(results)}"
+        )
+
+    return results
+
+
+def _summarize_snapshot_round(events: list[dict[str, Any]]) -> dict[str, Any]:
+    # Use each broker's own snapshot_timestamp (when it actually completed the
+    # snapshot) rather than the WebSocket event's timestamp (when the orchestrator
+    # emitted the event). The orchestrator emits all events in the same for-loop
+    # so event timestamps are indistinguishable; broker timestamps reflect real
+    # per-broker completion times.
+    timestamps = [
+        e.get("data", {}).get("snapshot_timestamp") or e.get("timestamp", 0)
+        for e in events
+    ]
+    if not timestamps:
+        return {"broker_count": 0, "coordination_ms": 0}
+    return {
+        "broker_count": len(events),
+        "coordination_ms": round((max(timestamps) - min(timestamps)) * 1000, 1),
+    }

--- a/benchmarks/config.py
+++ b/benchmarks/config.py
@@ -1,0 +1,72 @@
+"""Benchmark configuration — all knobs in one place."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:
+    from aether.orchestrator.settings import settings as orchestrator_settings
+except Exception:
+    orchestrator_settings = None
+
+
+def _default_recovery_snapshot_max_age() -> float:
+    if orchestrator_settings is not None:
+        return float(orchestrator_settings.snapshot_max_age)
+    return 45.0
+
+
+@dataclass
+class BenchmarkConfig:
+    orchestrator_url: str = "http://localhost:9000"
+    warmup_seconds: int = 10
+    measurement_seconds: int = 30
+    poll_interval: float = 1.0
+    min_throughput_samples: int = 3
+    metrics_max_staleness_seconds: float = 3.0
+    max_metrics_read_failures: int = 3
+    # Publisher send interval in seconds. 0.001 = 1000 msg/s per publisher.
+    # The default 1.0 used by /api/seed is intentionally throttled for the UI
+    # demo; benchmarks need the mesh pushed hard to find real limits.
+    publish_interval: float = 0.001
+    results_dir: Path = field(default_factory=lambda: Path("benchmarks/results"))
+
+    # Throughput benchmark matrix
+    broker_counts: list[int] = field(default_factory=lambda: [3, 5, 7, 10])
+    publisher_counts: list[int] = field(default_factory=lambda: [1, 2, 3, 5, 8])
+
+    # Latency benchmark
+    # publish_interval is intentionally slow here: the latency benchmark must
+    # keep the broker well below saturation so that queueing delay does not
+    # inflate the numbers.  0.05 s = 20 msg/s per publisher — roughly 1% of
+    # the broker's throughput capacity, so the measured latency reflects actual
+    # network + processing overhead rather than head-of-line blocking.
+    latency_brokers: int = 3
+    latency_publishers: int = 2
+    latency_subscribers: int = 3
+    latency_publish_interval: float = 0.05
+    latency_ready_timeout_seconds: float = 30.0
+    latency_ready_poll_interval: float = 1.0
+    latency_ready_consecutive_polls: int = 3
+    latency_min_samples_per_subscriber: int = 20
+
+    # Snapshot benchmark
+    snapshot_broker_counts: list[int] = field(default_factory=lambda: [3, 5, 7, 10])
+    snapshot_rounds: int = 3
+
+    # Recovery benchmark
+    recovery_trials: int = 5
+    recovery_path_a_trials: int = 3
+    recovery_path_a_delay_seconds: float = 2.0
+    recovery_snapshot_max_age_seconds: float = field(
+        default_factory=_default_recovery_snapshot_max_age
+    )
+    recovery_stale_margin_seconds: float = 5.0
+
+    # Scaling benchmark
+    scaling_brokers: int = 3
+    scaling_initial_publishers: int = 1
+    scaling_max_publishers: int = 10
+    scaling_subscribers: int = 3
+    scaling_step_seconds: int = 20

--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -93,12 +93,31 @@ export interface BrokerMetrics {
   snapshot_state: string;
 }
 
+export interface LatencyPercentiles {
+  p50: number;
+  p95: number;
+  p99: number;
+  sample_count: number;
+}
+
+export interface SubscriberMetrics {
+  subscriber_id: number;
+  broker_id: number | null;
+  total_received: number;
+  latency_us: LatencyPercentiles;
+}
+
 export interface MetricsResponse {
   brokers: BrokerMetrics[];
+  subscribers: SubscriberMetrics[];
   total_messages_processed: number;
   total_brokers: number;
   total_publishers: number;
   total_subscribers: number;
+  throughput_msgs_per_sec: number;
+  topology_generation: number;
+  fetched_at: number;
+  sample_interval_seconds: number;
 }
 
 export interface WebSocketEvent {

--- a/tests/unit/test_benchmark_client.py
+++ b/tests/unit/test_benchmark_client.py
@@ -1,0 +1,177 @@
+"""Unit tests for benchmark client helpers around metrics generations."""
+
+from __future__ import annotations
+
+import time
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from benchmarks.client import AetherClient
+from benchmarks.config import BenchmarkConfig
+
+
+class TestBenchmarkMetricsGenerationHelpers(unittest.IsolatedAsyncioTestCase):
+    async def asyncTearDown(self) -> None:
+        client = getattr(self, "client", None)
+        if client is not None:
+            await client.close()
+
+    async def test_wait_for_metrics_generation_waits_for_fresh_sample(self) -> None:
+        self.client = AetherClient(BenchmarkConfig())
+        self.client.get_metrics = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[
+                {"topology_generation": 1, "fetched_at": 0},
+                {"topology_generation": 2, "fetched_at": 0},
+                {"topology_generation": 2, "fetched_at": 1_700_000_100.0},
+            ]
+        )
+
+        metrics = await self.client.wait_for_metrics_generation(
+            2,
+            timeout=1.0,
+            poll_interval=0,
+        )
+
+        assert metrics["topology_generation"] == 2
+        assert metrics["fetched_at"] == 1_700_000_100.0
+
+    async def test_assert_metrics_generation_raises_on_drift(self) -> None:
+        self.client = AetherClient(BenchmarkConfig())
+        self.client.get_metrics = AsyncMock(  # type: ignore[method-assign]
+            return_value={"topology_generation": 3}
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "metrics generation changed during throughput window",
+        ):
+            await self.client.assert_metrics_generation(
+                2,
+                stage="throughput window",
+            )
+
+
+class TestBenchmarkMetricsContract(unittest.IsolatedAsyncioTestCase):
+    async def asyncTearDown(self) -> None:
+        client = getattr(self, "client", None)
+        if client is not None:
+            await client.close()
+
+    async def test_assert_valid_metrics_snapshot_rejects_stale_metrics(self) -> None:
+        self.client = AetherClient(BenchmarkConfig(metrics_max_staleness_seconds=2.0))
+
+        with patch("benchmarks.client.time.time", return_value=100.0):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "stale metrics snapshot during warmup",
+            ):
+                self.client.assert_valid_metrics_snapshot(
+                    {
+                        "topology_generation": 2,
+                        "fetched_at": 97.0,
+                        "sample_interval_seconds": 1.0,
+                    },
+                    stage="warmup",
+                    expected_generation=2,
+                )
+
+    async def test_assert_valid_metrics_snapshot_rejects_non_positive_sample_interval(
+        self,
+    ) -> None:
+        self.client = AetherClient(BenchmarkConfig())
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "invalid metrics sample interval during readiness",
+        ):
+            self.client.assert_valid_metrics_snapshot(
+                {
+                    "topology_generation": 5,
+                    "fetched_at": time.time(),
+                    "sample_interval_seconds": 0.0,
+                },
+                stage="readiness",
+                expected_generation=5,
+            )
+
+    async def test_wait_latency_ready_rejects_invalid_metrics_contract(self) -> None:
+        self.client = AetherClient(BenchmarkConfig(metrics_max_staleness_seconds=2.0))
+        self.client.get_state = AsyncMock(  # type: ignore[method-assign]
+            return_value={
+                "subscribers": [{"component_id": 1}],
+            }
+        )
+        self.client.get_metrics = AsyncMock(  # type: ignore[method-assign]
+            return_value={
+                "topology_generation": 1,
+                "fetched_at": 90.0,
+                "sample_interval_seconds": 1.0,
+                "total_messages_processed": 10,
+                "subscribers": [
+                    {
+                        "subscriber_id": 1,
+                        "total_received": 5,
+                        "latency_us": {"sample_count": 5},
+                    }
+                ],
+            }
+        )
+
+        with patch("benchmarks.client.time.time", return_value=100.0):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "stale metrics snapshot during latency readiness",
+            ):
+                await self.client.wait_latency_ready(
+                    expected_subscribers=1,
+                    min_samples_per_subscriber=1,
+                    stable_polls=1,
+                    timeout=0.1,
+                    poll_interval=0,
+                )
+
+
+class TestBenchmarkSeedTopology(unittest.IsolatedAsyncioTestCase):
+    async def asyncTearDown(self) -> None:
+        client = getattr(self, "client", None)
+        if client is not None:
+            await client.close()
+
+    async def test_seed_topology_rechecks_live_state_before_publishers_and_subscribers(
+        self,
+    ) -> None:
+        self.client = AetherClient(BenchmarkConfig())
+        self.client.get_state = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[
+                {"brokers": [], "publishers": [], "subscribers": []},
+                {
+                    "brokers": [{"component_id": 1}],
+                    "publishers": [{"component_id": 21}],
+                    "subscribers": [{"component_id": 31}],
+                },
+                {
+                    "brokers": [{"component_id": 1}],
+                    "publishers": [{"component_id": 21}],
+                    "subscribers": [{"component_id": 31}],
+                },
+                {
+                    "brokers": [{"component_id": 1}],
+                    "publishers": [{"component_id": 21}],
+                    "subscribers": [{"component_id": 31}],
+                },
+            ]
+        )
+        self.client._create_broker = AsyncMock(  # type: ignore[method-assign]
+            return_value={"component": {"component_id": 1}}
+        )
+        self.client._create_publisher = AsyncMock(  # type: ignore[method-assign]
+            return_value={"component": {"component_id": 41}}
+        )
+        self.client._create_subscriber = AsyncMock(  # type: ignore[method-assign]
+            return_value={"component": {"component_id": 51}}
+        )
+
+        await self.client.seed_topology(brokers=1, publishers=2, subscribers=2)
+
+        self.client._create_publisher.assert_awaited_once()
+        self.client._create_subscriber.assert_awaited_once()

--- a/tests/unit/test_benchmark_collectors.py
+++ b/tests/unit/test_benchmark_collectors.py
@@ -1,0 +1,76 @@
+"""Unit tests for shared benchmark collector hardening."""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock
+
+from benchmarks.collectors import (
+    collect_recovery_events,
+    collect_snapshot_events,
+    collect_throughput,
+)
+from benchmarks.config import BenchmarkConfig
+
+
+class _FakeClient:
+    def __init__(self, cfg: BenchmarkConfig) -> None:
+        self.cfg = cfg
+        self.get_metrics = AsyncMock()
+
+
+class TestCollectThroughput(unittest.IsolatedAsyncioTestCase):
+    async def test_collect_throughput_raises_after_repeated_metrics_failures(
+        self,
+    ) -> None:
+        client = _FakeClient(BenchmarkConfig(max_metrics_read_failures=2))
+        client.get_metrics.side_effect = RuntimeError("metrics unavailable")
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "failed to collect throughput metrics after 2 consecutive errors",
+        ):
+            await collect_throughput(client, duration=0.02, poll_interval=0)
+
+    async def test_collect_throughput_rejects_insufficient_samples(self) -> None:
+        client = _FakeClient(BenchmarkConfig(min_throughput_samples=2))
+        client.get_metrics.side_effect = [
+            {"total_messages_processed": 100},
+            {"total_messages_processed": 110},
+        ]
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "insufficient throughput samples",
+        ):
+            await collect_throughput(client, duration=0.03, poll_interval=0.02)
+
+
+class TestEventCollectors(unittest.IsolatedAsyncioTestCase):
+    async def test_collect_recovery_events_rejects_incomplete_timeline(self) -> None:
+        events: asyncio.Queue[dict] = asyncio.Queue()
+        events.put_nowait({"type": "broker_declared_dead", "timestamp": 10.0})
+        events.put_nowait({"type": "broker_recovery_started", "timestamp": 11.0})
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "incomplete recovery event timeline",
+        ):
+            await collect_recovery_events(events, timeout=0.05)
+
+    async def test_collect_snapshot_events_rejects_missing_rounds(self) -> None:
+        events: asyncio.Queue[dict] = asyncio.Queue()
+        events.put_nowait(
+            {
+                "type": "snapshot_complete",
+                "timestamp": 10.0,
+                "data": {"snapshot_timestamp": 10.0},
+            }
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "incomplete snapshot rounds",
+        ):
+            await collect_snapshot_events(events, rounds=2, timeout_per_round=0.01)

--- a/tests/unit/test_orchestrator_metrics_cache.py
+++ b/tests/unit/test_orchestrator_metrics_cache.py
@@ -1,0 +1,196 @@
+"""Unit tests for Phase 1 cached orchestrator metrics behavior.
+
+These tests lock in the intended Phase 1 contract:
+
+1. ``DockerManager.get_metrics()`` is a pure cache read and must not trigger
+   live broker/subscriber polling.
+2. One authoritative refresh path samples live status, updates cache metadata,
+   and computes throughput from sampler tick deltas rather than per-request
+   mutable globals.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from aether.orchestrator.docker_manager import DockerManager
+from aether.orchestrator.models import (
+    ComponentInfo,
+    ComponentStatus,
+    ComponentType,
+    CreateBrokerRequest,
+    MetricsResponse,
+)
+
+
+def _make_broker(broker_id: int) -> ComponentInfo:
+    return ComponentInfo(
+        component_type=ComponentType.BROKER,
+        component_id=broker_id,
+        container_name=f"aether-broker-{broker_id}",
+        hostname=f"broker-{broker_id}",
+        internal_port=8000,
+        internal_status_port=18000,
+        status=ComponentStatus.RUNNING,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_manager() -> DockerManager:
+    fake_client = MagicMock()
+    fake_client.networks.get.return_value = MagicMock()
+    with patch(
+        "aether.orchestrator.docker_manager.docker.from_env",
+        return_value=fake_client,
+    ):
+        return DockerManager()
+
+
+class TestMetricsCacheReadPath:
+    def test_get_metrics_returns_cached_snapshot_without_live_polling(self) -> None:
+        manager = _make_manager()
+        cached = MetricsResponse(
+            total_messages_processed=123,
+            total_brokers=1,
+            total_publishers=2,
+            total_subscribers=3,
+            throughput_msgs_per_sec=45.6,
+            topology_generation=7,
+        )
+
+        manager._metrics_cache = cached  # type: ignore[attr-defined]
+        manager._sync_component_status = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("get_metrics() must not sync component state")
+        )
+        manager._fetch_status = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError(
+                "get_metrics() must not poll live status endpoints"
+            )
+        )
+
+        result = manager.get_metrics()
+
+        assert result == cached
+
+
+class TestMetricsCacheRefresh:
+    def test_refresh_metrics_cache_uses_sampler_deltas_and_updates_metadata(
+        self,
+    ) -> None:
+        manager = _make_manager()
+        broker = _make_broker(1)
+        manager._components = {broker.container_name: broker}
+        manager._sync_component_status = MagicMock()  # type: ignore[method-assign]
+
+        manager._fetch_status = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "host": "broker-1",
+                "port": 8000,
+                "peer_count": 0,
+                "subscribers": {"count": 0},
+                "messages_processed": 100,
+                "uptime_seconds": 5.0,
+                "snapshot_state": "idle",
+            }
+        )
+
+        first = manager.refresh_metrics_cache(
+            now=100.0,
+            fetched_at=1_700_000_100.0,
+        )
+        assert first.total_messages_processed == 100
+        assert first.throughput_msgs_per_sec == 0
+        assert hasattr(first, "fetched_at")
+        assert first.fetched_at == 1_700_000_100.0
+        assert hasattr(first, "sample_interval_seconds")
+        assert first.sample_interval_seconds == 0.0
+        assert first.topology_generation == 0
+
+        manager._fetch_status = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "host": "broker-1",
+                "port": 8000,
+                "peer_count": 0,
+                "subscribers": {"count": 0},
+                "messages_processed": 160,
+                "uptime_seconds": 6.0,
+                "snapshot_state": "idle",
+            }
+        )
+
+        second = manager.refresh_metrics_cache(
+            now=101.0,
+            fetched_at=1_700_000_101.0,
+        )
+        assert second.total_messages_processed == 160
+        assert second.sample_interval_seconds == 1.0
+        assert second.throughput_msgs_per_sec == 60.0
+        assert second.fetched_at == 1_700_000_101.0
+
+    def test_topology_mutation_advances_generation_and_resets_cached_sample(self) -> None:
+        manager = _make_manager()
+        manager._metrics_cache = MetricsResponse(
+            total_messages_processed=75,
+            total_brokers=1,
+            throughput_msgs_per_sec=12.5,
+            fetched_at=1_700_000_000.0,
+            sample_interval_seconds=1.0,
+            topology_generation=0,
+        )
+        manager._last_total_messages = 75  # type: ignore[attr-defined]
+        manager._last_metrics_time = 50.0  # type: ignore[attr-defined]
+
+        manager.client.containers.run.return_value = MagicMock(id="broker-1-container")
+        broker = manager.create_broker(CreateBrokerRequest())
+
+        cached_after_create = manager.get_metrics()
+        assert broker.component_id == 1
+        assert cached_after_create.topology_generation == 1
+        assert cached_after_create.total_messages_processed == 0
+        assert cached_after_create.throughput_msgs_per_sec == 0
+        assert cached_after_create.fetched_at == 0
+        assert cached_after_create.sample_interval_seconds == 0
+        assert manager._last_total_messages == 0  # type: ignore[attr-defined]
+        assert manager._last_metrics_time == 0.0  # type: ignore[attr-defined]
+
+        removed_container = MagicMock()
+        manager.client.containers.get.return_value = removed_container
+        manager.remove_broker(broker.component_id)
+
+        cached_after_remove = manager.get_metrics()
+        assert cached_after_remove.topology_generation == 2
+        removed_container.stop.assert_called_once_with(timeout=10)
+        removed_container.remove.assert_called_once()
+
+
+class TestMetricsEndpointReadPath:
+    def test_metrics_route_reads_cache_without_refreshing(self) -> None:
+        fake_client = MagicMock()
+        fake_client.networks.get.return_value = MagicMock()
+
+        with patch(
+            "aether.orchestrator.docker_manager.docker.from_env",
+            return_value=fake_client,
+        ):
+            sys.modules.pop("aether.orchestrator.main", None)
+            main = importlib.import_module("aether.orchestrator.main")
+
+        cached = MetricsResponse(
+            total_messages_processed=321,
+            throughput_msgs_per_sec=12.3,
+            fetched_at=50.0,
+            sample_interval_seconds=1.0,
+            topology_generation=4,
+        )
+        main.docker_mgr.get_metrics = MagicMock(return_value=cached)
+        main.docker_mgr.refresh_metrics_cache = MagicMock(
+            side_effect=AssertionError("/api/metrics must not refresh live metrics")
+        )
+
+        result = asyncio.run(main.get_metrics())
+
+        assert result == cached


### PR DESCRIPTION
## Summary
- make orchestrator metrics sampler-owned and expose topology-aware cached metrics metadata to readers
- harden benchmark client validation, latency readiness, and topology seeding against stale metrics and topology drift
- make throughput, recovery, and snapshot collectors fail explicitly on invalid collection windows, with focused regression tests

## Test plan
- [x] `pytest tests/unit/test_benchmark_client.py tests/unit/test_benchmark_collectors.py tests/unit/test_orchestrator_metrics_cache.py -q`
- [x] `ruff check benchmarks/client.py benchmarks/collectors.py benchmarks/config.py tests/unit/test_benchmark_client.py tests/unit/test_benchmark_collectors.py`

Made with [Cursor](https://cursor.com)