### PR TITLE
feat(benchmarks): add latency instrumentation runtime support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ Thumbs.db
 
 # Claude / project-local files
 .claude/
+.opencode/
 CLAUDE.md
 config.yaml
 config-local.yaml
+
+# Generated benchmark outputs
+benchmarks/results/*
+!benchmarks/results/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for aether distributed messaging system
 # Targets documented in docs/instructions.md and docs/roadmap.md
 
-.PHONY: demo status logs clean build build-dashboard test lint up down restart ps check-ports purge-network
+.PHONY: demo status logs clean build build-dashboard test lint up down restart ps check-ports purge-network benchmark benchmark-charts
 
 # Colors for better output
 GREEN = \033[0;32m
@@ -36,6 +36,8 @@ help:
 	@echo "  $(YELLOW)make down$(NC)        - Stop compose services"
 	@echo "  $(YELLOW)make restart$(NC)     - Restart compose services"
 	@echo "  $(YELLOW)make ps$(NC)          - Show container status"
+	@echo "  $(YELLOW)make benchmark$(NC)    - Run full benchmark suite (requires: make demo)"
+	@echo "  $(YELLOW)make benchmark-charts$(NC) - Regenerate charts from existing results"
 	@echo "  $(YELLOW)make check-ports$(NC) - Check if required ports are available"
 	@echo ""
 	@echo "See docs/instructions.md for detailed usage"
@@ -134,6 +136,14 @@ check-ports:
 		exit 1; \
 	fi
 	@echo "$(GREEN)All required ports are available.$(NC)"
+
+benchmark:
+	@echo "$(YELLOW)Running benchmark suite (requires: make demo)...$(NC)"
+	python3 -m benchmarks.runner
+
+benchmark-charts:
+	@echo "$(YELLOW)Regenerating charts from existing results...$(NC)"
+	python3 -m benchmarks.runner --charts-only
 
 # Local development targets (without Docker)
 install:

--- a/aether/cli/run_publishers.py
+++ b/aether/cli/run_publishers.py
@@ -50,7 +50,10 @@ def main():
         "--broker-host",
         action="append",
         default=None,
-        help="Broker host (repeatable, e.g. --broker-host broker-1 --broker-host broker-2)",
+        help=(
+            "Broker host (repeatable, e.g. "
+            "--broker-host broker-1 --broker-host broker-2)"
+        ),
     )
     parser.add_argument(
         "--broker-port",
@@ -78,7 +81,10 @@ def main():
     else:
         if args.publisher_id < 0 or args.publisher_id >= config.publisher_count:
             logger.error(
-                "publisher ID %d out of range [0, %d) — provide --host and --port to bypass",
+                (
+                    "publisher ID %d out of range [0, %d) "
+                    "— provide --host and --port to bypass"
+                ),
                 args.publisher_id,
                 config.publisher_count,
             )
@@ -130,6 +136,12 @@ def main():
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 
+    # Throttle per-message logs: at fast intervals (e.g., 0.001s = 1000 msg/s)
+    # logging every message floods stdout and becomes the bottleneck. Log once
+    # per second's worth of messages so benchmarks can actually measure the
+    # broker mesh, not the logger.
+    log_every = max(1, int(round(1.0 / args.interval))) if args.interval > 0 else 1
+
     msg_count = 0
     try:
         while True:
@@ -137,12 +149,13 @@ def main():
             sent = publisher.publish(Message(payload), redundancy=2)
             msg_count += 1
 
-            logger.info(
-                "published payload=%d sent_to=%d broker(s) (total: %d)",
-                payload,
-                sent,
-                msg_count,
-            )
+            if msg_count % log_every == 0:
+                logger.info(
+                    "published payload=%d sent_to=%d broker(s) (total: %d)",
+                    payload,
+                    sent,
+                    msg_count,
+                )
 
             time.sleep(args.interval)
     except Exception:

--- a/aether/gossip/broker.py
+++ b/aether/gossip/broker.py
@@ -195,7 +195,9 @@ class GossipBroker:
                 self._messages_processed += 1
 
             self._local_broker.publish(gossip_msg.msg)
-            self._deliver_to_remote_subscribers(gossip_msg.msg)
+            self._deliver_to_remote_subscribers(
+                gossip_msg.msg, gossip_msg.send_timestamp_ns
+            )
 
             if gossip_msg.ttl > 0:
                 self._gossip_to_peers(gossip_msg)
@@ -209,6 +211,7 @@ class GossipBroker:
             msg_id=gossip_msg.msg_id,
             ttl=gossip_msg.ttl - 1,
             source=gossip_msg.source,
+            send_timestamp_ns=gossip_msg.send_timestamp_ns,
         )
 
         if len(self.peer_brokers) == 0:
@@ -729,11 +732,15 @@ class GossipBroker:
             "remote subscriber unregistered %s range=%s", subscriber, payload_range
         )
 
-    def _deliver_to_remote_subscribers(self, msg: Message) -> None:
+    def _deliver_to_remote_subscribers(
+        self, msg: Message, send_timestamp_ns: int = 0
+    ) -> None:
         remote_subs = self._payload_to_remotes[msg.payload]
         for subscriber_addr in remote_subs:
             try:
-                delivery = PayloadMessageDelivery(msg)
+                delivery = PayloadMessageDelivery(
+                    msg=msg, send_timestamp_ns=send_timestamp_ns
+                )
                 self.network.send(delivery, subscriber_addr)
                 self.log.debug(
                     "delivered payload=%d to remote subscriber %s",

--- a/aether/gossip/protocol.py
+++ b/aether/gossip/protocol.py
@@ -16,6 +16,7 @@ class GossipMessage:
     msg_id: str
     ttl: int
     source: NodeAddress
+    send_timestamp_ns: int = 0
 
 
 @dataclass
@@ -84,3 +85,4 @@ class PayloadMessageDelivery:
     """
 
     msg: Message
+    send_timestamp_ns: int = 0

--- a/aether/gossip/status.py
+++ b/aether/gossip/status.py
@@ -113,7 +113,8 @@ class _StatusHandler(BaseHTTPRequestHandler):
     # ------------------------------------------------------------------ #
 
     def _handle_recover(self) -> None:
-        # Parse JSON body — RecoveryManager sends {"dead_broker_host": ..., "dead_broker_port": ...}
+        # RecoveryManager sends:
+        # {"dead_broker_host": ..., "dead_broker_port": ...}
         try:
             length = int(self.headers.get("Content-Length", 0))
             body = json.loads(self.rfile.read(length))
@@ -362,11 +363,31 @@ class _SubscriberStatusHandler(BaseHTTPRequestHandler):
         else:
             self._send_json({"error": "not found"}, status=404)
 
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path == "/latency/reset":
+            self._handle_latency_reset()
+        else:
+            self._send_json({"error": "not found"}, status=404)
+
     def _handle_status(self) -> None:
         sub = self.subscriber
         now = time.time()
 
         uptime = round(now - sub._start_time, 1)
+
+        # Compute latency percentiles from collected samples.
+        samples = sorted(sub.latency_samples_snapshot_ns())
+        latency_samples_us = [round(sample / 1000, 1) for sample in samples]
+        if samples:
+            n = len(samples)
+            latency_us: dict[str, float | int] = {
+                "p50": round(samples[n // 2] / 1000, 1),
+                "p95": round(samples[int(n * 0.95)] / 1000, 1),
+                "p99": round(samples[int(n * 0.99)] / 1000, 1),
+                "sample_count": n,
+            }
+        else:
+            latency_us = {"p50": 0, "p95": 0, "p99": 0, "sample_count": 0}
 
         payload: dict[str, Any] = {
             "subscriber": str(sub.address),
@@ -380,9 +401,18 @@ class _SubscriberStatusHandler(BaseHTTPRequestHandler):
             "total_received": sub.total_received,
             "running": sub.running,
             "uptime_seconds": uptime,
+            "latency_us": latency_us,
+            "latency_samples_us": latency_samples_us,
         }
 
         self._send_json(payload, status=200)
+
+    def _handle_latency_reset(self) -> None:
+        cleared = self.subscriber.clear_latency_samples()
+        self._send_json(
+            {"status": "ok", "cleared_samples": cleared},
+            status=200,
+        )
 
     def _send_json(self, data: dict, *, status: int) -> None:
         body = json.dumps(data, indent=2).encode("utf-8")

--- a/aether/network/publisher.py
+++ b/aether/network/publisher.py
@@ -67,6 +67,7 @@ class NetworkPublisher:
             msg_id=msg_id,
             ttl=self.ttl,
             source=self.address,
+            send_timestamp_ns=time.monotonic_ns(),
         )
 
         sent_count = 0

--- a/aether/network/subscriber.py
+++ b/aether/network/subscriber.py
@@ -4,6 +4,7 @@ import random
 import threading
 import time
 import urllib.request
+from collections import deque
 from typing import Optional, Set
 
 from aether.core.message import Message
@@ -47,6 +48,8 @@ class NetworkSubscriber:
         "_last_pong_time",
         "_ping_sequence",
         "_health_thread",
+        "_latency_samples_ns",
+        "_latency_samples_lock",
     )
 
     def __init__(
@@ -76,6 +79,8 @@ class NetworkSubscriber:
         self._broker_alive: bool = True
         self._last_pong_time: float = time.time()
         self._ping_sequence: int = 0
+        self._latency_samples_ns: deque[int] = deque(maxlen=10_000)
+        self._latency_samples_lock = threading.Lock()
 
     def connect_to_broker(self, broker_address: NodeAddress) -> None:
         self.broker = broker_address
@@ -117,6 +122,16 @@ class NetworkSubscriber:
 
     def handle_incoming_message(self, msg: Message) -> None:
         self.subscriber.handle_msg(msg)
+
+    def latency_samples_snapshot_ns(self) -> list[int]:
+        with self._latency_samples_lock:
+            return list(self._latency_samples_ns)
+
+    def clear_latency_samples(self) -> int:
+        with self._latency_samples_lock:
+            cleared = len(self._latency_samples_ns)
+            self._latency_samples_ns.clear()
+            return cleared
 
     def unsubscribe(self, payload_range: PayloadRange, retries: int = 3) -> bool:
         if self.broker is None:
@@ -168,9 +183,10 @@ class NetworkSubscriber:
 
         if self.broker == old_broker:
             self.log.info(
-                "broker recovered: %s -> %s, updating reference",
+                "broker recovery notification received: %s -> %s",
                 old_broker,
                 new_broker,
+                extra={"event_type": "subscriber_reconnected"},
             )
             self.broker = new_broker
             self._broker_alive = True
@@ -222,6 +238,11 @@ class NetworkSubscriber:
             if isinstance(msg, PayloadMessageDelivery):
                 self.total_received += 1
                 self.subscriber.handle_msg(msg.msg)
+                if msg.send_timestamp_ns > 0:
+                    with self._latency_samples_lock:
+                        self._latency_samples_ns.append(
+                            time.monotonic_ns() - msg.send_timestamp_ns
+                        )
                 self.log.info(
                     "received payload=%d from broker %s", msg.msg.payload, sender
                 )

--- a/aether/orchestrator/metrics.py
+++ b/aether/orchestrator/metrics.py
@@ -71,13 +71,15 @@ recovery_duration_seconds = Histogram(
 
 subscriber_reconnects_total = Counter(
     "aether_subscriber_reconnects_total",
-    # What it counts: subscriber reassignments triggered by the orchestrator
-    # during redistribution recovery. Each subscriber moved to a new broker
-    # increments this by 1. This is a control-plane view — it only counts
-    # reconnects the orchestrator orchestrated, not self-healed reconnects
-    # that subscribers negotiated directly (those are visible in Loki via
-    # event_type="subscriber_reconnected").
-    "Total subscriber reassignments performed by the orchestrator during recovery.",
+    # What it counts: subscriber reconnection activity during broker recovery
+    # and reassignment. Redistribution increments this once per orphan moved;
+    # replacement increments it once per subscriber restored from snapshot;
+    # intentional broker deletion uses the same accounting as redistribution.
+    #
+    # This remains a control-plane view — it counts the subscribers affected by
+    # recovery, while Loki's event_type="subscriber_reconnected" logs show the
+    # subscriber-side confirmation that connectivity was restored.
+    "Total subscribers affected by recovery-driven reconnection or reassignment.",
 )
 
 # ---------------------------------------------------------------------------
@@ -89,7 +91,8 @@ component_up = Gauge(
     # What it tracks: 1 if the component container is in RUNNING state according
     # to the orchestrator's DockerManager, 0 otherwise. Updated every 15 seconds
     # by the background metrics updater in main.py.
-    # Use this to build alerts: alert when sum(aether_component_up{component_type="broker"}) < 2.
+    # Use this to build alerts:
+    # alert when sum(aether_component_up{component_type="broker"}) < 2.
     "Whether a managed component is currently running (1 = up, 0 = down).",
     ["component_type", "component_id"],  # e.g. broker/1, subscriber/3
 )
@@ -127,6 +130,8 @@ messages_published_total = Counter(
     # resets (e.g. broker container restart) won't inflate the count, but may
     # cause a small gap. For precise per-message accounting, use Loki with
     # event_type="message_published" instead.
-    "Cumulative messages processed across all brokers (approximated from /status polling).",
+    (
+        "Cumulative messages processed across all brokers "
+        "(approximated from /status polling)."
+    ),
 )
-

--- a/aether/orchestrator/recovery.py
+++ b/aether/orchestrator/recovery.py
@@ -5,6 +5,7 @@ import uuid
 
 import httpx
 
+from aether.orchestrator import metrics
 from aether.orchestrator.models import (
     ComponentInfo,
     ComponentStatus,
@@ -12,7 +13,6 @@ from aether.orchestrator.models import (
     CreateBrokerRequest,
     EventType,
 )
-from aether.orchestrator import metrics
 from aether.utils.log import BoundLogger
 
 logger = BoundLogger(
@@ -30,6 +30,18 @@ class RecoveryManager:
             int, float
         ] = {}  # broker_id → timestamp (debounce)
         self._lock = asyncio.Lock()
+
+    @staticmethod
+    def _snapshot_subscriber_count(snapshot: dict | None) -> int:
+        """Best-effort count of subscribers captured in a serialized snapshot."""
+        if not snapshot:
+            return 0
+
+        remote_subscribers = snapshot.get("remote_subscribers")
+        if isinstance(remote_subscribers, dict):
+            return len(remote_subscribers)
+
+        return 0
 
     async def handle_broker_dead(self, broker_id: int, host: str, port: int) -> None:
         now = time.time()
@@ -81,7 +93,10 @@ class RecoveryManager:
                     and (now - snapshot["timestamp"]) < self._settings.snapshot_max_age
                 ):
                     logger.info(
-                        "fresh snapshot found (%.1fs old) — attempting replacement recovery",
+                        (
+                            "fresh snapshot found (%.1fs old) "
+                            "— attempting replacement recovery"
+                        ),
                         now - snapshot["timestamp"],
                     )
                     try:
@@ -97,7 +112,10 @@ class RecoveryManager:
                             recovery_path="replacement", result="failure"
                         ).inc()
                         logger.exception(
-                            "replacement recovery failed for broker %d — falling back to redistribution",
+                            (
+                                "replacement recovery failed for broker %d "
+                                "— falling back to redistribution"
+                            ),
                             broker_id,
                             extra={
                                 "event_type": "broker_recovery_failed",
@@ -142,7 +160,7 @@ class RecoveryManager:
         dead_host: str,
         dead_port: int,
     ) -> dict | None:
-        """Query all surviving brokers for snapshots of the dead broker, return the freshest."""
+        """Query surviving brokers and return the freshest snapshot available."""
         if not alive_brokers:
             return None
 
@@ -181,7 +199,7 @@ class RecoveryManager:
         recovery_id: str,
         t0: float,
     ) -> None:
-        """Path A: spin up a replacement broker with the same ID and restore from snapshot."""
+        """Path A: replace the dead broker and restore it from a snapshot."""
         logger.info(
             "broker %d replacement recovery started",
             broker_id,
@@ -239,7 +257,10 @@ class RecoveryManager:
 
         if not healthy:
             raise RuntimeError(
-                f"Replacement broker {broker_id} did not become healthy within {self._settings.health_timeout}s"
+                (
+                    f"Replacement broker {broker_id} did not become healthy within "
+                    f"{self._settings.health_timeout}s"
+                )
             )
 
         # 5. POST /recover to restore state from the dead broker's snapshot
@@ -261,6 +282,9 @@ class RecoveryManager:
             recovery_path="replacement", result="success"
         ).inc()
         metrics.recovery_duration_seconds.observe(time.time() - t0)
+        metrics.subscriber_reconnects_total.inc(
+            self._snapshot_subscriber_count(snapshot)
+        )
 
         logger.info(
             "broker %d replacement recovery complete",
@@ -474,4 +498,5 @@ class RecoveryManager:
             broker_id,
             len(orphaned_subscribers),
         )
+        metrics.subscriber_reconnects_total.inc(len(orphaned_subscribers))
         return len(orphaned_subscribers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ dev = [
     "mypy>=1.8.0",
     "types-PyYAML>=6.0"
 ]
+benchmark = [
+    "matplotlib>=3.8.0",
+    "websockets>=12.0",
+]
 
 [project.scripts]
 aether-admin = "aether.cli.admin:main"

--- a/tests/unit/test_recovery_manager.py
+++ b/tests/unit/test_recovery_manager.py
@@ -164,7 +164,8 @@ class TestPathBStaleSnapshot(unittest.IsolatedAsyncioTestCase):
 
         await recovery.handle_broker_dead(2, "broker-2", 8000)
 
-        recovery._recover_redistribution.assert_called_once_with(2)
+        recovery._recover_redistribution.assert_awaited_once()
+        self.assertEqual(recovery._recover_redistribution.await_args.args[0], 2)
 
 
 class TestPathBNoSnapshot(unittest.IsolatedAsyncioTestCase):
@@ -185,7 +186,8 @@ class TestPathBNoSnapshot(unittest.IsolatedAsyncioTestCase):
 
         await recovery.handle_broker_dead(2, "broker-2", 8000)
 
-        recovery._recover_redistribution.assert_called_once_with(2)
+        recovery._recover_redistribution.assert_awaited_once()
+        self.assertEqual(recovery._recover_redistribution.await_args.args[0], 2)
 
 
 class TestPathAFallbackToB(unittest.IsolatedAsyncioTestCase):
@@ -212,7 +214,8 @@ class TestPathAFallbackToB(unittest.IsolatedAsyncioTestCase):
         await recovery.handle_broker_dead(2, "broker-2", 8000)
 
         recovery._recover_replacement.assert_called_once()
-        recovery._recover_redistribution.assert_called_once_with(2)
+        recovery._recover_redistribution.assert_awaited_once()
+        self.assertEqual(recovery._recover_redistribution.await_args.args[0], 2)
 
 
 class TestRedistributionBalancing(unittest.IsolatedAsyncioTestCase):
@@ -238,7 +241,7 @@ class TestRedistributionBalancing(unittest.IsolatedAsyncioTestCase):
         settings = _mock_settings()
 
         recovery = RecoveryManager(docker_mgr, broadcaster, settings)
-        await recovery._recover_redistribution(3)
+        await recovery._recover_redistribution(3, "recovery-123", time.time())
 
         # broker2 had 0 subs, broker1 had 1 — least-loaded first
         # Expected: orphan1 → broker2 (0), orphan2 → broker1 (1) or broker2 (1),
@@ -254,6 +257,66 @@ class TestRedistributionBalancing(unittest.IsolatedAsyncioTestCase):
         # With 1 existing on broker1, final counts should be balanced: 2 and 2
         self.assertIn(assigned_to_1 + 1, [2, 2])  # broker1 total
         self.assertIn(assigned_to_2, [1, 2])  # broker2 total
+
+
+class TestReconnectMetrics(unittest.IsolatedAsyncioTestCase):
+    """Subscriber reconnect metrics cover all recovery flows."""
+
+    async def test_replacement_counts_snapshot_subscribers(self):
+        broker1 = _make_broker(1)
+        broker2 = _make_broker(2)
+        docker_mgr = _mock_docker_mgr(_components(broker1, broker2))
+        broadcaster = MagicMock()
+        broadcaster.emit = AsyncMock()
+        settings = _mock_settings()
+
+        recovery = RecoveryManager(docker_mgr, broadcaster, settings)
+        snapshot = {
+            "timestamp": time.time() - 5.0,
+            "remote_subscribers": {
+                "subscriber-1:9100": [{"low": 0, "high": 84}],
+                "subscriber-2:9100": [{"low": 85, "high": 169}],
+            },
+        }
+
+        with patch(
+            "aether.orchestrator.metrics.subscriber_reconnects_total.inc"
+        ) as inc:
+            with patch("httpx.AsyncClient") as MockClient:
+                mock_client = AsyncMock()
+                mock_client.request = AsyncMock()
+                mock_client.get = AsyncMock(return_value=MagicMock(status_code=200))
+                mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
+                MockClient.return_value.__aenter__ = AsyncMock(
+                    return_value=mock_client
+                )
+                MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+                await recovery._recover_replacement(
+                    2, "broker-2", 8000, snapshot, "recovery-123", time.time()
+                )
+
+        inc.assert_called_once_with(2)
+
+    async def test_intentional_delete_counts_reassigned_subscribers(self):
+        broker1 = _make_broker(1)
+        broker2 = _make_broker(2)
+        orphan1 = _make_subscriber(1, broker_id=2)
+        orphan2 = _make_subscriber(2, broker_id=2)
+        docker_mgr = _mock_docker_mgr(_components(broker1, broker2, orphan1, orphan2))
+        broadcaster = MagicMock()
+        broadcaster.emit = AsyncMock()
+        settings = _mock_settings()
+
+        recovery = RecoveryManager(docker_mgr, broadcaster, settings)
+
+        with patch(
+            "aether.orchestrator.metrics.subscriber_reconnects_total.inc"
+        ) as inc:
+            reassigned = await recovery.reassign_orphans(2)
+
+        self.assertEqual(reassigned, 2)
+        inc.assert_called_once_with(2)
 
 
 class TestFetchBestSnapshotPicksFreshest(unittest.IsolatedAsyncioTestCase):
@@ -317,9 +380,7 @@ class TestConcurrentRecoverySerialized(unittest.IsolatedAsyncioTestCase):
 
         execution_order = []
 
-        original_redistribute = recovery._recover_redistribution
-
-        async def tracked_redistribute(broker_id):
+        async def tracked_redistribute(broker_id, recovery_id, t0):
             execution_order.append(("start", broker_id))
             await asyncio.sleep(0.05)
             execution_order.append(("end", broker_id))

--- a/tests/unit/test_subscriber_reconnect.py
+++ b/tests/unit/test_subscriber_reconnect.py
@@ -8,17 +8,15 @@ tests fast.
 from __future__ import annotations
 
 import json
-import threading
 import time
 import unittest
-from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 from aether.core.payload_range import PayloadRange
 from aether.core.uint8 import UInt8
 from aether.gossip.protocol import SubscribeRequest
 from aether.network.node import NodeAddress
-from aether.network.subscriber import NetworkSubscriber, _PING_INTERVAL, _PING_TIMEOUT
+from aether.network.subscriber import NetworkSubscriber
 from aether.snapshot import BrokerRecoveryNotification, Ping, Pong
 
 
@@ -125,7 +123,9 @@ class TestReconnectSuccess(unittest.TestCase):
         mock_resp.__exit__ = MagicMock(return_value=False)
 
         sent = []
-        sub.node.send = MagicMock(side_effect=lambda msg, addr: sent.append((msg, addr)))
+        sub.node.send = MagicMock(
+            side_effect=lambda msg, addr: sent.append((msg, addr))
+        )
 
         with patch("urllib.request.urlopen", return_value=mock_resp):
             with patch("random.uniform", return_value=0):
@@ -174,17 +174,21 @@ class TestReconnectSuccess(unittest.TestCase):
         sub._broker_alive = False
         sub.running = False  # already stopped
 
-        with patch("urllib.request.urlopen", side_effect=AssertionError("should not call")):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=AssertionError("should not call"),
+        ):
             sub._reconnect()  # should return immediately without calling urlopen
 
 
 class TestBrokerRecoveryNotificationFastPath(unittest.TestCase):
-    """BrokerRecoveryNotification resets health state — no pull-based reconnect needed."""
+    """Recovery notifications reset health without a pull-based reconnect."""
 
     def test_recovery_notification_resets_health_state(self):
         sub = _make_subscriber()
         sub._broker_alive = False
         sub._last_pong_time = time.time() - 100
+        sub.log.info = MagicMock()
 
         old_broker = NodeAddress("broker-1", 8000)
         new_broker = NodeAddress("broker-2", 8000)
@@ -198,6 +202,10 @@ class TestBrokerRecoveryNotificationFastPath(unittest.TestCase):
         self.assertTrue(sub._broker_alive)
         self.assertEqual(sub.broker, new_broker)
         self.assertAlmostEqual(sub._last_pong_time, time.time(), delta=1.0)
+        self.assertEqual(
+            sub.log.info.call_args.kwargs["extra"]["event_type"],
+            "subscriber_reconnected",
+        )
 
     def test_recovery_notification_ignored_for_other_broker(self):
         sub = _make_subscriber()


### PR DESCRIPTION
## Summary
- thread send timestamps through publisher, broker, and subscriber delivery paths so latency can be sampled at the subscriber edge
- expose subscriber latency percentiles, raw samples, and a reset endpoint for benchmark collection
- tighten recovery/reconnect metrics and add benchmark-oriented runtime helpers, including benchmark extras and make targets

## Test plan
- [x] `pytest tests/unit/test_recovery_manager.py tests/unit/test_subscriber_reconnect.py -q`
- [x] `ruff check aether/cli/run_publishers.py aether/gossip/broker.py aether/gossip/protocol.py aether/gossip/status.py aether/network/publisher.py aether/network/subscriber.py aether/orchestrator/metrics.py aether/orchestrator/recovery.py tests/unit/test_recovery_manager.py tests/unit/test_subscriber_reconnect.py`

Made with [Cursor](https://cursor.com)