### PR TITLE
fix(benchmarks): validate throughput and latency windows

### DIFF
--- a/benchmarks/collectors.py
+++ b/benchmarks/collectors.py
@@ -13,6 +13,9 @@ async def collect_throughput(
     client: AetherClient,
     duration: float,
     poll_interval: float = 1.0,
+    *,
+    expected_generation: int | None = None,
+    stage: str = "throughput measurement",
 ) -> list[dict[str, Any]]:
     """Poll /api/metrics for *duration* seconds and return per-interval samples.
 
@@ -24,9 +27,17 @@ async def collect_throughput(
     prev_time: float | None = None
     consecutive_failures = 0
 
+    current_generation = expected_generation
     while time.monotonic() - start < duration:
         try:
             metrics = await client.get_metrics()
+            client.assert_valid_metrics_snapshot(
+                metrics,
+                stage=stage,
+                expected_generation=current_generation,
+            )
+            if current_generation is None:
+                current_generation = metrics["topology_generation"]
             consecutive_failures = 0
             now = time.monotonic()
             if "total_messages_processed" not in metrics:
@@ -64,6 +75,36 @@ async def collect_throughput(
         )
 
     return samples
+
+
+def classify_throughput_window(
+    samples: list[dict[str, Any]],
+    *,
+    active_publishers: int,
+    near_zero_msgs_per_sec: float,
+    max_near_zero_sample_ratio: float,
+) -> str | None:
+    """Return an explicit invalidity reason when a throughput window looks poisoned."""
+    if not samples:
+        return "throughput window produced no samples"
+
+    if active_publishers <= 0:
+        return None
+
+    near_zero_count = sum(
+        1
+        for sample in samples
+        if float(sample.get("msgs_per_sec", 0.0)) <= near_zero_msgs_per_sec
+    )
+    near_zero_ratio = near_zero_count / len(samples)
+    if near_zero_ratio > max_near_zero_sample_ratio:
+        return (
+            "throughput window has too many near-zero samples under active "
+            f"publishers: {near_zero_count}/{len(samples)} at or below "
+            f"{near_zero_msgs_per_sec:.1f} msg/s"
+        )
+
+    return None
 
 
 def compute_stats(values: list[float]) -> dict[str, float]:
@@ -127,6 +168,49 @@ async def collect_latency(
     aggregate["sample_count"] = len(all_samples_us)
 
     return {"subscribers": subscriber_latencies, "aggregate": aggregate}
+
+
+def classify_latency_window(
+    latency_data: dict[str, Any],
+    *,
+    expected_subscribers: int,
+    min_samples_per_subscriber: int,
+    processed_messages_delta: int,
+    expected_messages: float,
+    min_delivery_ratio: float,
+) -> str | None:
+    """Return an explicit invalidity reason when a latency window is not trustworthy."""
+    subscriber_data = latency_data.get("subscribers", [])
+    if len(subscriber_data) != expected_subscribers:
+        return (
+            "latency benchmark invalid: expected "
+            f"{expected_subscribers} subscribers with samples, got "
+            f"{len(subscriber_data)}"
+        )
+
+    undersampled = [
+        f"{sub['subscriber_id']}:{sub['sample_count']}"
+        for sub in subscriber_data
+        if sub.get("sample_count", 0) < min_samples_per_subscriber
+    ]
+    if undersampled:
+        return (
+            "latency benchmark invalid: subscribers below minimum sample count "
+            f"({min_samples_per_subscriber}): {undersampled}"
+        )
+
+    if expected_messages > 0:
+        observed_ratio = processed_messages_delta / expected_messages
+        if observed_ratio < min_delivery_ratio:
+            return (
+                "latency benchmark invalid: observed processed-message ratio "
+                f"{observed_ratio:.2f} below unsaturated floor "
+                f"{min_delivery_ratio:.2f} "
+                f"(processed_delta={processed_messages_delta}, "
+                f"expected_messages={expected_messages:.1f})"
+            )
+
+    return None
 
 
 def _compute_percentiles(sorted_values: list[float]) -> dict[str, float]:

--- a/benchmarks/config.py
+++ b/benchmarks/config.py
@@ -26,6 +26,13 @@ class BenchmarkConfig:
     min_throughput_samples: int = 3
     metrics_max_staleness_seconds: float = 3.0
     max_metrics_read_failures: int = 3
+    window_retry_limit: int = 2
+    throughput_retry_backoff_seconds: float = 2.0
+    scaling_retry_backoff_seconds: float = 3.0
+    near_zero_msgs_per_sec: float = 1.0
+    max_near_zero_sample_ratio: float = 0.5
+    scaling_saturation_gain_threshold_pct: float = 5.0
+    scaling_saturation_consecutive_steps: int = 2
     # Publisher send interval in seconds. 0.001 = 1000 msg/s per publisher.
     # The default 1.0 used by /api/seed is intentionally throttled for the UI
     # demo; benchmarks need the mesh pushed hard to find real limits.
@@ -50,6 +57,7 @@ class BenchmarkConfig:
     latency_ready_poll_interval: float = 1.0
     latency_ready_consecutive_polls: int = 3
     latency_min_samples_per_subscriber: int = 20
+    latency_min_delivery_ratio: float = 0.7
 
     # Snapshot benchmark
     snapshot_broker_counts: list[int] = field(default_factory=lambda: [3, 5, 7, 10])

--- a/benchmarks/latency.py
+++ b/benchmarks/latency.py
@@ -9,7 +9,7 @@ import time
 from typing import Any
 
 from benchmarks.client import AetherClient
-from benchmarks.collectors import collect_latency
+from benchmarks.collectors import classify_latency_window, collect_latency
 from benchmarks.config import BenchmarkConfig
 
 logger = logging.getLogger(__name__)
@@ -76,9 +76,21 @@ async def run(cfg: BenchmarkConfig) -> dict[str, Any]:
         await client.reset_all_subscriber_latency_samples(
             expected_subscribers=cfg.latency_subscribers
         )
+        metrics_before = await client.get_metrics()
+        client.assert_valid_metrics_snapshot(
+            metrics_before,
+            stage="latency measurement start",
+        )
+        measurement_generation = metrics_before["topology_generation"]
 
         logger.info("latency: measuring for %ds...", cfg.measurement_seconds)
         await asyncio.sleep(cfg.measurement_seconds)
+        metrics_after = await client.get_metrics()
+        client.assert_valid_metrics_snapshot(
+            metrics_after,
+            stage="latency measurement end",
+            expected_generation=measurement_generation,
+        )
         await client.assert_topology_matches(
             expected_topology,
             stage="latency measurement",
@@ -86,24 +98,27 @@ async def run(cfg: BenchmarkConfig) -> dict[str, Any]:
 
         # Harvest latency data from subscribers.
         latency_data = await collect_latency(client)
-        subscriber_data = latency_data.get("subscribers", [])
-        if len(subscriber_data) != cfg.latency_subscribers:
-            raise RuntimeError(
-                "latency benchmark invalid: expected "
-                f"{cfg.latency_subscribers} subscribers with samples, got "
-                f"{len(subscriber_data)}"
-            )
-
-        undersampled = [
-            f"{sub['subscriber_id']}:{sub['sample_count']}"
-            for sub in subscriber_data
-            if sub.get("sample_count", 0) < cfg.latency_min_samples_per_subscriber
-        ]
-        if undersampled:
-            raise RuntimeError(
-                "latency benchmark invalid: subscribers below minimum sample count "
-                f"({cfg.latency_min_samples_per_subscriber}): {undersampled}"
-            )
+        processed_messages_delta = (
+            int(metrics_after.get("total_messages_processed", 0))
+            - int(metrics_before.get("total_messages_processed", 0))
+        )
+        expected_messages = (
+            cfg.latency_publishers
+            * cfg.measurement_seconds
+            / cfg.latency_publish_interval
+            if cfg.latency_publish_interval > 0
+            else 0.0
+        )
+        invalid_reason = classify_latency_window(
+            latency_data,
+            expected_subscribers=cfg.latency_subscribers,
+            min_samples_per_subscriber=cfg.latency_min_samples_per_subscriber,
+            processed_messages_delta=processed_messages_delta,
+            expected_messages=expected_messages,
+            min_delivery_ratio=cfg.latency_min_delivery_ratio,
+        )
+        if invalid_reason is not None:
+            raise RuntimeError(invalid_reason)
 
         agg = latency_data.get("aggregate", {})
         logger.info(

--- a/benchmarks/scaling.py
+++ b/benchmarks/scaling.py
@@ -9,10 +9,78 @@ import time
 from typing import Any
 
 from benchmarks.client import AetherClient
-from benchmarks.collectors import collect_throughput
+from benchmarks.collectors import classify_throughput_window, collect_throughput
 from benchmarks.config import BenchmarkConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _find_saturation_point(
+    timeline: list[dict[str, Any]],
+    *,
+    gain_threshold_pct: float,
+    consecutive_steps: int,
+) -> dict[str, Any] | None:
+    """Return saturation point after consecutive low-gain steps."""
+    low_gain_streak = 0
+
+    for i in range(1, len(timeline)):
+        prev_rate = timeline[i - 1]["mean_msgs_per_sec"]
+        curr_rate = timeline[i]["mean_msgs_per_sec"]
+        if prev_rate <= 0:
+            low_gain_streak = 0
+            continue
+
+        pct_increase = (curr_rate - prev_rate) / prev_rate * 100
+        if pct_increase < gain_threshold_pct:
+            low_gain_streak += 1
+            if low_gain_streak >= consecutive_steps:
+                return {
+                    "publishers": timeline[i]["publishers"],
+                    "throughput": curr_rate,
+                    "pct_increase_from_prev": round(pct_increase, 1),
+                    "gain_threshold_pct": gain_threshold_pct,
+                    "consecutive_low_gain_steps": low_gain_streak,
+                }
+        else:
+            low_gain_streak = 0
+
+    return None
+
+
+async def _measure_scaling_step(
+    client: AetherClient,
+    cfg: BenchmarkConfig,
+    *,
+    publishers: int,
+) -> list[dict[str, Any]]:
+    expected_topology = await client.get_topology_fingerprint()
+    metrics = await client.get_metrics()
+    client.assert_valid_metrics_snapshot(metrics, stage="scaling measurement")
+    expected_generation = metrics["topology_generation"]
+
+    samples = await collect_throughput(
+        client,
+        cfg.scaling_step_seconds,
+        cfg.poll_interval,
+        expected_generation=expected_generation,
+        stage="scaling measurement",
+    )
+    await client.assert_topology_matches(
+        expected_topology,
+        stage="scaling measurement",
+    )
+
+    invalid_reason = classify_throughput_window(
+        samples,
+        active_publishers=publishers,
+        near_zero_msgs_per_sec=cfg.near_zero_msgs_per_sec,
+        max_near_zero_sample_ratio=cfg.max_near_zero_sample_ratio,
+    )
+    if invalid_reason is not None:
+        raise RuntimeError(invalid_reason)
+
+    return samples
 
 
 async def run(cfg: BenchmarkConfig) -> dict[str, Any]:
@@ -41,7 +109,13 @@ async def run(cfg: BenchmarkConfig) -> dict[str, Any]:
             cfg.scaling_initial_publishers,
             cfg.scaling_subscribers,
         )
-        await client.wait_all_running(timeout=60)
+        try:
+            await client.wait_all_running(timeout=60)
+        except RuntimeError as exc:
+            raise RuntimeError(
+                "scaling startup timeout before first measurement: "
+                f"{exc}"
+            ) from exc
 
         logger.info("scaling: warmup (%ds)...", cfg.warmup_seconds)
         await asyncio.sleep(cfg.warmup_seconds)
@@ -59,11 +133,41 @@ async def run(cfg: BenchmarkConfig) -> dict[str, Any]:
                 current_publishers,
                 cfg.scaling_step_seconds,
             )
+            max_attempts = 1 + cfg.window_retry_limit
+            samples: list[dict[str, Any]] | None = None
+            attempt_used = 0
+            last_error: RuntimeError | None = None
 
-            # Measure throughput for one step.
-            samples = await collect_throughput(
-                client, cfg.scaling_step_seconds, cfg.poll_interval
-            )
+            for attempt in range(1, max_attempts + 1):
+                attempt_used = attempt
+                try:
+                    samples = await _measure_scaling_step(
+                        client,
+                        cfg,
+                        publishers=current_publishers,
+                    )
+                    break
+                except RuntimeError as exc:
+                    last_error = exc
+                    if attempt >= max_attempts:
+                        raise RuntimeError(
+                            "scaling step invalid after retry budget at "
+                            f"{current_publishers} publishers: {exc}"
+                        ) from exc
+
+                    logger.warning(
+                        "scaling step invalid, retrying after %.1fs: %s",
+                        cfg.scaling_retry_backoff_seconds,
+                        exc,
+                    )
+                    await asyncio.sleep(cfg.scaling_retry_backoff_seconds)
+
+            if samples is None:
+                raise RuntimeError(
+                    "scaling step failed without samples"
+                    if last_error is None
+                    else str(last_error)
+                )
 
             rates = [s["msgs_per_sec"] for s in samples]
             if rates:
@@ -75,6 +179,7 @@ async def run(cfg: BenchmarkConfig) -> dict[str, Any]:
                 "elapsed": round(time.monotonic() - start, 1),
                 "publishers": current_publishers,
                 "mean_msgs_per_sec": round(mean_rate, 1),
+                "attempts": attempt_used,
                 "samples": samples,
             }
             timeline.append(step_entry)
@@ -92,6 +197,7 @@ async def run(cfg: BenchmarkConfig) -> dict[str, Any]:
             current_publishers += 1
             try:
                 await client.add_publisher(broker_ids=broker_ids)
+                await client.wait_all_running(timeout=60)
                 publisher_additions.append(
                     {
                         "elapsed": round(time.monotonic() - start, 1),
@@ -101,27 +207,20 @@ async def run(cfg: BenchmarkConfig) -> dict[str, Any]:
                 # Brief pause for the new publisher to start.
                 await asyncio.sleep(3)
             except Exception as exc:
-                logger.warning("failed to add publisher: %s", exc)
-                break
+                raise RuntimeError(
+                    "scaling publisher startup timeout at "
+                    f"{current_publishers} publishers: {exc}"
+                ) from exc
 
     finally:
         await client.cleanup()
         await client.close()
 
-    # Find saturation point: where adding a publisher increases throughput < 5%.
-    saturation_point: dict[str, Any] | None = None
-    for i in range(1, len(timeline)):
-        prev_rate = timeline[i - 1]["mean_msgs_per_sec"]
-        curr_rate = timeline[i]["mean_msgs_per_sec"]
-        if prev_rate > 0:
-            pct_increase = (curr_rate - prev_rate) / prev_rate * 100
-            if pct_increase < 5.0:
-                saturation_point = {
-                    "publishers": timeline[i]["publishers"],
-                    "throughput": curr_rate,
-                    "pct_increase_from_prev": round(pct_increase, 1),
-                }
-                break
+    saturation_point = _find_saturation_point(
+        timeline,
+        gain_threshold_pct=cfg.scaling_saturation_gain_threshold_pct,
+        consecutive_steps=cfg.scaling_saturation_consecutive_steps,
+    )
 
     output = {
         "benchmark": "scaling",

--- a/benchmarks/throughput.py
+++ b/benchmarks/throughput.py
@@ -9,10 +9,58 @@ import time
 from typing import Any
 
 from benchmarks.client import AetherClient
-from benchmarks.collectors import collect_throughput, compute_stats
+from benchmarks.collectors import (
+    classify_throughput_window,
+    collect_throughput,
+    compute_stats,
+)
 from benchmarks.config import BenchmarkConfig
 
 logger = logging.getLogger(__name__)
+
+
+async def _measure_throughput_attempt(
+    client: AetherClient,
+    cfg: BenchmarkConfig,
+    *,
+    n_publishers: int,
+) -> list[dict[str, Any]]:
+    expected_topology = await client.get_topology_fingerprint()
+    metrics = await client.get_metrics()
+    client.assert_valid_metrics_snapshot(metrics, stage="throughput warmup")
+    expected_generation = metrics["topology_generation"]
+
+    logger.info("  warmup (%ds)...", cfg.warmup_seconds)
+    await asyncio.sleep(cfg.warmup_seconds)
+    await client.assert_topology_matches(expected_topology, stage="throughput warmup")
+    await client.assert_metrics_generation(
+        expected_generation,
+        stage="throughput warmup",
+    )
+
+    logger.info("  measuring (%ds)...", cfg.measurement_seconds)
+    samples = await collect_throughput(
+        client,
+        cfg.measurement_seconds,
+        cfg.poll_interval,
+        expected_generation=expected_generation,
+        stage="throughput measurement",
+    )
+    await client.assert_topology_matches(
+        expected_topology,
+        stage="throughput measurement",
+    )
+
+    invalid_reason = classify_throughput_window(
+        samples,
+        active_publishers=n_publishers,
+        near_zero_msgs_per_sec=cfg.near_zero_msgs_per_sec,
+        max_near_zero_sample_ratio=cfg.max_near_zero_sample_ratio,
+    )
+    if invalid_reason is not None:
+        raise RuntimeError(invalid_reason)
+
+    return samples
 
 
 async def run(cfg: BenchmarkConfig) -> dict[str, Any]:
@@ -30,59 +78,84 @@ async def run(cfg: BenchmarkConfig) -> dict[str, Any]:
                 logger.info(
                     "throughput: %d brokers, %d publishers", n_brokers, n_publishers
                 )
-
-                # Clean slate.
-                await client.cleanup()
-                await asyncio.sleep(2)
-
-                # Seed topology.
                 n_subscribers = max(3, n_brokers)
-                await client.seed_topology(n_brokers, n_publishers, n_subscribers)
+                max_attempts = 1 + cfg.window_retry_limit
+                last_error: RuntimeError | None = None
 
-                try:
-                    await client.wait_all_running(timeout=60)
-                except RuntimeError:
-                    logger.warning(
-                        "timeout waiting for components — skipping %d/%d",
+                for attempt in range(1, max_attempts + 1):
+                    logger.info(
+                        "  attempt %d/%d for %d broker(s), %d publisher(s)",
+                        attempt,
+                        max_attempts,
                         n_brokers,
                         n_publishers,
                     )
-                    results.append(
-                        {
-                            "brokers": n_brokers,
-                            "publishers": n_publishers,
-                            "status": "timeout",
-                        }
+                    await client.cleanup()
+                    await asyncio.sleep(2)
+                    await client.seed_topology(n_brokers, n_publishers, n_subscribers)
+
+                    try:
+                        await client.wait_all_running(timeout=60)
+                        samples = await _measure_throughput_attempt(
+                            client,
+                            cfg,
+                            n_publishers=n_publishers,
+                        )
+                    except RuntimeError as exc:
+                        last_error = exc
+                        if attempt >= max_attempts:
+                            status = (
+                                "timeout"
+                                if "RUNNING within" in str(exc)
+                                else "invalid"
+                            )
+                            results.append(
+                                {
+                                    "brokers": n_brokers,
+                                    "publishers": n_publishers,
+                                    "subscribers": n_subscribers,
+                                    "status": status,
+                                    "attempts": attempt,
+                                    "invalid_reason": str(exc),
+                                }
+                            )
+                            logger.warning(
+                                "  %s after %d attempt(s): %s",
+                                status,
+                                attempt,
+                                exc,
+                            )
+                            break
+
+                        logger.warning(
+                            "  invalid throughput window, retrying after %.1fs: %s",
+                            cfg.throughput_retry_backoff_seconds,
+                            exc,
+                        )
+                        await asyncio.sleep(cfg.throughput_retry_backoff_seconds)
+                        continue
+
+                    rates = [s["msgs_per_sec"] for s in samples]
+                    stats = compute_stats(rates)
+                    entry = {
+                        "brokers": n_brokers,
+                        "publishers": n_publishers,
+                        "subscribers": n_subscribers,
+                        "status": "ok",
+                        "attempts": attempt,
+                        "stats": stats,
+                        "samples": samples,
+                    }
+                    results.append(entry)
+                    logger.info(
+                        "  result: mean=%.1f msg/s, p95=%.1f msg/s",
+                        stats["mean"],
+                        stats["p95"],
                     )
-                    continue
-
-                # Warmup.
-                logger.info("  warmup (%ds)...", cfg.warmup_seconds)
-                await asyncio.sleep(cfg.warmup_seconds)
-
-                # Measure.
-                logger.info("  measuring (%ds)...", cfg.measurement_seconds)
-                samples = await collect_throughput(
-                    client, cfg.measurement_seconds, cfg.poll_interval
-                )
-
-                rates = [s["msgs_per_sec"] for s in samples]
-                stats = compute_stats(rates)
-
-                entry = {
-                    "brokers": n_brokers,
-                    "publishers": n_publishers,
-                    "subscribers": n_subscribers,
-                    "status": "ok",
-                    "stats": stats,
-                    "samples": samples,
-                }
-                results.append(entry)
-                logger.info(
-                    "  result: mean=%.1f msg/s, p95=%.1f msg/s",
-                    stats["mean"],
-                    stats["p95"],
-                )
+                    break
+                else:
+                    if last_error is not None:
+                        raise last_error
 
     finally:
         await client.cleanup()

--- a/tests/unit/test_benchmark_collectors.py
+++ b/tests/unit/test_benchmark_collectors.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import unittest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from benchmarks.collectors import (
+    classify_latency_window,
+    classify_throughput_window,
     collect_recovery_events,
     collect_snapshot_events,
     collect_throughput,
@@ -18,9 +20,46 @@ class _FakeClient:
     def __init__(self, cfg: BenchmarkConfig) -> None:
         self.cfg = cfg
         self.get_metrics = AsyncMock()
+        self.assert_valid_metrics_snapshot = MagicMock()
 
 
 class TestCollectThroughput(unittest.IsolatedAsyncioTestCase):
+    async def test_collect_throughput_validates_metrics_contract_per_sample(
+        self,
+    ) -> None:
+        client = _FakeClient(BenchmarkConfig(min_throughput_samples=2))
+        client.get_metrics.side_effect = [
+            {
+                "topology_generation": 4,
+                "fetched_at": 100.0,
+                "sample_interval_seconds": 1.0,
+                "total_messages_processed": 100,
+            },
+            {
+                "topology_generation": 4,
+                "fetched_at": 101.0,
+                "sample_interval_seconds": 1.0,
+                "total_messages_processed": 110,
+            },
+            {
+                "topology_generation": 4,
+                "fetched_at": 102.0,
+                "sample_interval_seconds": 1.0,
+                "total_messages_processed": 120,
+            },
+        ]
+
+        samples = await collect_throughput(
+            client,
+            duration=0.03,
+            poll_interval=0.01,
+            expected_generation=4,
+            stage="throughput measurement",
+        )
+
+        self.assertGreaterEqual(len(samples), 2)
+        client.assert_valid_metrics_snapshot.assert_called()
+
     async def test_collect_throughput_raises_after_repeated_metrics_failures(
         self,
     ) -> None:
@@ -45,6 +84,74 @@ class TestCollectThroughput(unittest.IsolatedAsyncioTestCase):
             "insufficient throughput samples",
         ):
             await collect_throughput(client, duration=0.03, poll_interval=0.02)
+
+
+class TestClassifyThroughputWindow(unittest.TestCase):
+    def test_invalidates_window_with_too_many_near_zero_samples(self) -> None:
+        reason = classify_throughput_window(
+            [
+                {"msgs_per_sec": 0.0},
+                {"msgs_per_sec": 0.5},
+                {"msgs_per_sec": 25.0},
+            ],
+            active_publishers=2,
+            near_zero_msgs_per_sec=1.0,
+            max_near_zero_sample_ratio=0.5,
+        )
+
+        self.assertIn("too many near-zero samples", reason)
+
+    def test_allows_window_with_healthy_rate_distribution(self) -> None:
+        reason = classify_throughput_window(
+            [
+                {"msgs_per_sec": 50.0},
+                {"msgs_per_sec": 55.0},
+                {"msgs_per_sec": 60.0},
+            ],
+            active_publishers=2,
+            near_zero_msgs_per_sec=1.0,
+            max_near_zero_sample_ratio=0.5,
+        )
+
+        self.assertIsNone(reason)
+
+
+class TestClassifyLatencyWindow(unittest.TestCase):
+    def test_rejects_undersampled_subscribers(self) -> None:
+        reason = classify_latency_window(
+            {
+                "subscribers": [
+                    {"subscriber_id": 1, "sample_count": 5},
+                    {"subscriber_id": 2, "sample_count": 25},
+                ],
+                "aggregate": {"sample_count": 30},
+            },
+            expected_subscribers=2,
+            min_samples_per_subscriber=20,
+            processed_messages_delta=100,
+            expected_messages=100.0,
+            min_delivery_ratio=0.7,
+        )
+
+        self.assertIn("below minimum sample count", reason)
+
+    def test_rejects_window_with_low_processed_message_ratio(self) -> None:
+        reason = classify_latency_window(
+            {
+                "subscribers": [
+                    {"subscriber_id": 1, "sample_count": 25},
+                    {"subscriber_id": 2, "sample_count": 25},
+                ],
+                "aggregate": {"sample_count": 50},
+            },
+            expected_subscribers=2,
+            min_samples_per_subscriber=20,
+            processed_messages_delta=20,
+            expected_messages=100.0,
+            min_delivery_ratio=0.7,
+        )
+
+        self.assertIn("processed-message ratio", reason)
 
 
 class TestEventCollectors(unittest.IsolatedAsyncioTestCase):

--- a/tests/unit/test_benchmark_phase4.py
+++ b/tests/unit/test_benchmark_phase4.py
@@ -1,0 +1,204 @@
+"""Unit tests for Phase 4 throughput and scaling benchmark repairs."""
+
+from __future__ import annotations
+
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from benchmarks.config import BenchmarkConfig
+from benchmarks.scaling import _find_saturation_point
+
+
+def _metrics_snapshot() -> dict[str, float | int]:
+    return {
+        "topology_generation": 7,
+        "fetched_at": time.time(),
+        "sample_interval_seconds": 1.0,
+        "total_messages_processed": 100,
+    }
+
+
+def _fake_client() -> MagicMock:
+    client = MagicMock()
+    client.cleanup = AsyncMock()
+    client.close = AsyncMock()
+    client.seed_topology = AsyncMock(return_value={"seeded": 0})
+    client.wait_all_running = AsyncMock()
+    client.get_topology_fingerprint = AsyncMock(
+        return_value={"brokers": {1: "running"}}
+    )
+    client.get_metrics = AsyncMock(return_value=_metrics_snapshot())
+    client.assert_valid_metrics_snapshot = MagicMock()
+    client.assert_metrics_generation = AsyncMock()
+    client.assert_topology_matches = AsyncMock()
+    client.get_state = AsyncMock(
+        return_value={"brokers": [{"component_id": 1}, {"component_id": 2}]}
+    )
+    client.add_publisher = AsyncMock(return_value={"component": {"component_id": 3}})
+    return client
+
+
+class TestThroughputPhase4(unittest.IsolatedAsyncioTestCase):
+    async def test_run_retries_invalid_row_then_succeeds(self) -> None:
+        from benchmarks import throughput
+
+        bad_samples = [
+            {"msgs_per_sec": 0.0},
+            {"msgs_per_sec": 0.2},
+            {"msgs_per_sec": 10.0},
+        ]
+        good_samples = [
+            {"msgs_per_sec": 50.0},
+            {"msgs_per_sec": 55.0},
+            {"msgs_per_sec": 60.0},
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = BenchmarkConfig(
+                broker_counts=[3],
+                publisher_counts=[1],
+                warmup_seconds=0,
+                measurement_seconds=1,
+                results_dir=Path(tmpdir),
+                throughput_retry_backoff_seconds=0,
+            )
+            client = _fake_client()
+
+            with (
+                patch("benchmarks.throughput.AetherClient", return_value=client),
+                patch(
+                    "benchmarks.throughput.collect_throughput",
+                    new=AsyncMock(side_effect=[bad_samples, good_samples]),
+                ) as collect_mock,
+                patch("benchmarks.throughput.asyncio.sleep", new=AsyncMock()),
+            ):
+                output = await throughput.run(cfg)
+
+        result = output["results"][0]
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["attempts"], 2)
+        self.assertEqual(collect_mock.await_count, 2)
+
+    async def test_run_records_invalid_row_after_retry_budget_and_continues(
+        self,
+    ) -> None:
+        from benchmarks import throughput
+
+        bad_samples = [
+            {"msgs_per_sec": 0.0},
+            {"msgs_per_sec": 0.3},
+            {"msgs_per_sec": 10.0},
+        ]
+        good_samples = [
+            {"msgs_per_sec": 80.0},
+            {"msgs_per_sec": 85.0},
+            {"msgs_per_sec": 90.0},
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = BenchmarkConfig(
+                broker_counts=[3],
+                publisher_counts=[1, 2],
+                warmup_seconds=0,
+                measurement_seconds=1,
+                results_dir=Path(tmpdir),
+                throughput_retry_backoff_seconds=0,
+            )
+            client = _fake_client()
+
+            with (
+                patch("benchmarks.throughput.AetherClient", return_value=client),
+                patch(
+                    "benchmarks.throughput.collect_throughput",
+                    new=AsyncMock(
+                        side_effect=[
+                            bad_samples,
+                            bad_samples,
+                            bad_samples,
+                            good_samples,
+                        ]
+                    ),
+                ) as collect_mock,
+                patch("benchmarks.throughput.asyncio.sleep", new=AsyncMock()),
+            ):
+                output = await throughput.run(cfg)
+
+        first, second = output["results"]
+        self.assertEqual(first["status"], "invalid")
+        self.assertEqual(first["attempts"], 3)
+        self.assertIn("near-zero", first["invalid_reason"])
+        self.assertEqual(second["status"], "ok")
+        self.assertEqual(collect_mock.await_count, 4)
+
+
+class TestScalingPhase4(unittest.IsolatedAsyncioTestCase):
+    def test_find_saturation_point_requires_consecutive_low_gain_steps(self) -> None:
+        timeline = [
+            {"publishers": 1, "mean_msgs_per_sec": 100.0},
+            {"publishers": 2, "mean_msgs_per_sec": 140.0},
+            {"publishers": 3, "mean_msgs_per_sec": 143.0},
+            {"publishers": 4, "mean_msgs_per_sec": 145.0},
+        ]
+
+        saturation = _find_saturation_point(
+            timeline,
+            gain_threshold_pct=5.0,
+            consecutive_steps=2,
+        )
+
+        self.assertIsNotNone(saturation)
+        self.assertEqual(saturation["publishers"], 4)
+        self.assertEqual(saturation["consecutive_low_gain_steps"], 2)
+
+    async def test_run_retries_invalid_scaling_step_then_succeeds(self) -> None:
+        from benchmarks import scaling
+
+        step1_samples = [
+            {"msgs_per_sec": 100.0},
+            {"msgs_per_sec": 105.0},
+            {"msgs_per_sec": 110.0},
+        ]
+        bad_step2_samples = [
+            {"msgs_per_sec": 0.0},
+            {"msgs_per_sec": 0.2},
+            {"msgs_per_sec": 15.0},
+        ]
+        good_step2_samples = [
+            {"msgs_per_sec": 130.0},
+            {"msgs_per_sec": 132.0},
+            {"msgs_per_sec": 134.0},
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = BenchmarkConfig(
+                warmup_seconds=0,
+                scaling_initial_publishers=1,
+                scaling_max_publishers=2,
+                scaling_step_seconds=1,
+                results_dir=Path(tmpdir),
+                scaling_retry_backoff_seconds=0,
+            )
+            client = _fake_client()
+
+            with (
+                patch("benchmarks.scaling.AetherClient", return_value=client),
+                patch(
+                    "benchmarks.scaling.collect_throughput",
+                    new=AsyncMock(
+                        side_effect=[
+                            step1_samples,
+                            bad_step2_samples,
+                            good_step2_samples,
+                        ]
+                    ),
+                ) as collect_mock,
+                patch("benchmarks.scaling.asyncio.sleep", new=AsyncMock()),
+            ):
+                output = await scaling.run(cfg)
+
+        self.assertEqual(len(output["timeline"]), 2)
+        self.assertEqual(output["timeline"][1]["attempts"], 2)
+        self.assertEqual(collect_mock.await_count, 3)

--- a/tests/unit/test_benchmark_phase5.py
+++ b/tests/unit/test_benchmark_phase5.py
@@ -1,0 +1,131 @@
+"""Unit tests for Phase 5 latency benchmark repairs."""
+
+from __future__ import annotations
+
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from benchmarks.config import BenchmarkConfig
+
+
+def _metrics_snapshot(total: int) -> dict[str, float | int]:
+    return {
+        "topology_generation": 9,
+        "fetched_at": time.time(),
+        "sample_interval_seconds": 1.0,
+        "total_messages_processed": total,
+    }
+
+
+def _fake_client() -> MagicMock:
+    client = MagicMock()
+    client.cleanup = AsyncMock()
+    client.close = AsyncMock()
+    client.seed_topology = AsyncMock(return_value={"seeded": 0})
+    client.wait_all_running = AsyncMock()
+    client.get_topology_fingerprint = AsyncMock(
+        return_value={"brokers": {1: "running"}}
+    )
+    client.wait_latency_ready = AsyncMock()
+    client.assert_topology_matches = AsyncMock()
+    client.reset_all_subscriber_latency_samples = AsyncMock()
+    client.get_metrics = AsyncMock(
+        side_effect=[_metrics_snapshot(100), _metrics_snapshot(120)]
+    )
+    client.assert_valid_metrics_snapshot = MagicMock()
+    return client
+
+
+class TestLatencyPhase5(unittest.IsolatedAsyncioTestCase):
+    async def test_run_fails_fast_when_post_reset_window_is_underserved(self) -> None:
+        from benchmarks import latency
+
+        latency_data = {
+            "subscribers": [
+                {"subscriber_id": 1, "sample_count": 25},
+                {"subscriber_id": 2, "sample_count": 25},
+                {"subscriber_id": 3, "sample_count": 25},
+            ],
+            "aggregate": {
+                "p50": 1000.0,
+                "p95": 1500.0,
+                "p99": 2000.0,
+                "sample_count": 75,
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = BenchmarkConfig(
+                warmup_seconds=0,
+                measurement_seconds=10,
+                results_dir=Path(tmpdir),
+                latency_publish_interval=0.05,
+                latency_publishers=2,
+                latency_subscribers=3,
+                latency_min_samples_per_subscriber=20,
+                latency_min_delivery_ratio=0.7,
+            )
+            client = _fake_client()
+
+            with (
+                patch("benchmarks.latency.AetherClient", return_value=client),
+                patch(
+                    "benchmarks.latency.collect_latency",
+                    new=AsyncMock(return_value=latency_data),
+                ),
+                patch("benchmarks.latency.asyncio.sleep", new=AsyncMock()),
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "processed-message ratio",
+                ):
+                    await latency.run(cfg)
+
+    async def test_run_succeeds_for_valid_post_reset_window(self) -> None:
+        from benchmarks import latency
+
+        latency_data = {
+            "subscribers": [
+                {"subscriber_id": 1, "sample_count": 25},
+                {"subscriber_id": 2, "sample_count": 24},
+                {"subscriber_id": 3, "sample_count": 23},
+            ],
+            "aggregate": {
+                "p50": 900.0,
+                "p95": 1400.0,
+                "p99": 1800.0,
+                "sample_count": 72,
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = BenchmarkConfig(
+                warmup_seconds=0,
+                measurement_seconds=2,
+                results_dir=Path(tmpdir),
+                latency_publish_interval=0.05,
+                latency_publishers=2,
+                latency_subscribers=3,
+                latency_min_samples_per_subscriber=20,
+                latency_min_delivery_ratio=0.4,
+            )
+            client = _fake_client()
+            client.get_metrics = AsyncMock(
+                side_effect=[_metrics_snapshot(100), _metrics_snapshot(150)]
+            )
+
+            with (
+                patch("benchmarks.latency.AetherClient", return_value=client),
+                patch(
+                    "benchmarks.latency.collect_latency",
+                    new=AsyncMock(return_value=latency_data),
+                ),
+                patch("benchmarks.latency.asyncio.sleep", new=AsyncMock()),
+            ):
+                output = await latency.run(cfg)
+
+        self.assertEqual(output["benchmark"], "latency")
+        self.assertEqual(output["results"]["aggregate"]["sample_count"], 72)

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -49,6 +49,25 @@ def _get(port: int, path: str = "/status"):
             return exc, None
 
 
+def _post(port: int, path: str):
+    """Make a POST request and return (http_response, parsed_json_or_None)."""
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=b"{}",
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            body = resp.read().decode("utf-8")
+            return resp, json.loads(body)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8")
+        try:
+            return exc, json.loads(body)
+        except json.JSONDecodeError:
+            return exc, None
+
+
 class TestStatusServer(unittest.TestCase):
     """Tests for StatusServer / _StatusHandler."""
 
@@ -346,6 +365,8 @@ class TestSubscriberStatusServer(unittest.TestCase):
                 "total_received",
                 "running",
                 "uptime_seconds",
+                "latency_us",
+                "latency_samples_us",
             }
             missing = required_keys - data.keys()
             self.assertEqual(missing, set(), f"Missing keys: {missing}")
@@ -354,6 +375,8 @@ class TestSubscriberStatusServer(unittest.TestCase):
             self.assertIsInstance(data["total_received"], int)
             self.assertIsInstance(data["running"], bool)
             self.assertIsInstance(data["uptime_seconds"], float)
+            self.assertIsInstance(data["latency_us"], dict)
+            self.assertIsInstance(data["latency_samples_us"], list)
         finally:
             server.stop()
             sub.node.close()
@@ -383,6 +406,38 @@ class TestSubscriberStatusServer(unittest.TestCase):
             self.assertEqual(after["broker"], str(broker_addr))
             self.assertTrue(after["running"])
             self.assertEqual(after["total_received"], 42)
+        finally:
+            server.stop()
+            sub.node.close()
+
+    def test_status_reports_latency_samples_and_percentiles(self) -> None:
+        """Subscriber /status exposes raw latency samples and percentile summary."""
+        sub, server, port = self._make_subscriber_and_server()
+        sub._latency_samples_ns.extend([1_000_000, 2_000_000, 3_000_000])
+        server.start()
+        try:
+            _, data = _get(port, "/status")
+            self.assertEqual(data["latency_us"]["sample_count"], 3)
+            self.assertEqual(data["latency_us"]["p50"], 2000.0)
+            self.assertEqual(data["latency_samples_us"], [1000.0, 2000.0, 3000.0])
+        finally:
+            server.stop()
+            sub.node.close()
+
+    def test_latency_reset_clears_subscriber_samples(self) -> None:
+        """POST /latency/reset clears the in-memory subscriber latency buffer."""
+        sub, server, port = self._make_subscriber_and_server()
+        sub._latency_samples_ns.extend([1_000_000, 2_000_000])
+        server.start()
+        try:
+            resp, data = _post(port, "/latency/reset")
+            self.assertEqual(resp.status, 200)
+            self.assertEqual(data["status"], "ok")
+            self.assertEqual(data["cleared_samples"], 2)
+
+            _, after = _get(port, "/status")
+            self.assertEqual(after["latency_us"]["sample_count"], 0)
+            self.assertEqual(after["latency_samples_us"], [])
         finally:
             server.stop()
             sub.node.close()


### PR DESCRIPTION
## Summary
- add explicit invalid-window classification for throughput, scaling, and latency benchmarks so poisoned measurements are retried or failed instead of silently accepted
- tighten throughput and scaling behavior with bounded retries, invalid row recording, and a steadier consecutive-step saturation rule
- make latency runs fail fast after reset when harvested samples are undersized or the measured window does not look like the intended unsaturated experiment

## Test plan
- [x] `pytest tests/unit/test_benchmark_collectors.py tests/unit/test_benchmark_phase4.py -q`
- [x] `pytest tests/unit/test_benchmark_client.py tests/unit/test_benchmark_collectors.py tests/unit/test_benchmark_phase5.py tests/unit/test_status.py -q`
- [x] `ruff check benchmarks/config.py benchmarks/collectors.py benchmarks/throughput.py benchmarks/scaling.py benchmarks/latency.py tests/unit/test_benchmark_collectors.py tests/unit/test_benchmark_phase4.py tests/unit/test_benchmark_phase5.py tests/unit/test_status.py`

Made with [Cursor](https://cursor.com)